### PR TITLE
Bulk Events API implementation

### DIFF
--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -12,11 +12,13 @@ import android.location.LocationManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.blueshift.batch.BulkEventManager;
+import com.blueshift.batch.Event;
+import com.blueshift.batch.EventsTable;
 import com.blueshift.gcm.GCMRegistrar;
 import com.blueshift.httpmanager.Method;
 import com.blueshift.httpmanager.Request;
@@ -63,11 +65,39 @@ public class Blueshift {
     }
 
     /**
+     * This method return the only object of the class Blueshift
+     *
+     * @param context valid context object
+     * @return instance of Blueshift
+     */
+    public synchronized static Blueshift getInstance(Context context) {
+        mContext = context;
+
+        if (instance == null) {
+            instance = new Blueshift();
+        }
+
+        return instance;
+    }
+
+    /**
+     * Updates the mDeviceParams with new device token
+     *
+     * @param deviceToken device token for sending push message
+     */
+    public static void updateDeviceToken(String deviceToken) {
+        if (deviceToken != null && mDeviceParams != null) {
+            mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_TOKEN, deviceToken);
+        }
+    }
+
+    /**
      * This method creates a hash map with all device parameters filled in.
+     *
      * @return params: hash-map with device parameters filled in.
      */
     private HashMap<String, Object> getDeviceParams() {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         if (mDeviceParams != null) {
             params.putAll(mDeviceParams);
         }
@@ -79,7 +109,7 @@ public class Blueshift {
      * This method initializes the mDeviceParams hash map with device related information.
      */
     private void initializeDeviceParams() {
-        mDeviceParams = new HashMap<String, Object>();
+        mDeviceParams = new HashMap<>();
         mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_TYPE, "android");
         mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_TOKEN, GCMRegistrar.getRegistrationId(mContext));
         mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDFA, "");
@@ -96,57 +126,8 @@ public class Blueshift {
     }
 
     /**
-     * Updates the mDeviceParams with new device token
-     * @param deviceToken device token for sending push message
-     */
-    public static void updateDeviceToken(String deviceToken) {
-        if (deviceToken != null && mDeviceParams != null) {
-            mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_TOKEN, deviceToken);
-        }
-    }
-
-    /**
-     * Updates the mDeviceParams with advertising ID
-     */
-    private class FetchAndUpdateAdIdTask extends AsyncTask<Void, Void, String> {
-
-        @Override
-        protected void onPreExecute() {
-            Log.d(LOG_TAG, "Trying to fetch AdvertisingId");
-        }
-
-        @Override
-        protected String doInBackground(Void... params) {
-            return DeviceUtils.getAdvertisingID(mContext);
-        }
-
-        @Override
-        protected void onPostExecute(String adId) {
-            if (!TextUtils.isEmpty(adId)) {
-                mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, adId);
-            } else {
-                Log.d(LOG_TAG, "Could not fetch AdvertisingId");
-            }
-        }
-    }
-
-    /**
-     * This method return the only object of the class Blueshift
-     * @param context valid context object
-     * @return instance of Blueshift
-     */
-    public synchronized static Blueshift getInstance(Context context) {
-        mContext = context;
-
-        if (instance == null) {
-            instance = new Blueshift();
-        }
-
-        return instance;
-    }
-
-    /**
      * This method initializes the sdk with the configuration set by user
+     *
      * @param configuration this object contains all the mandatory parameters like api key, deep-link pages etc.
      */
     public void initialize(Configuration configuration) {
@@ -155,14 +136,18 @@ public class Blueshift {
         GCMRegistrar.registerForNotification(mContext);
         // Collecting device specific params.
         initializeDeviceParams();
-        // Trigger app open event
-        trackAppOpen();
+        // Trigger app open event.
+        // events sent by SDK are always batched.
+        trackAppOpen(true);
         // Sync the http request queue.
         RequestQueue.getInstance(mContext).sync();
+        // register alarm manager
+        BulkEventManager.startAlarmManager(mContext);
     }
 
     /**
      * Method to get the current configuration
+     *
      * @return configuration
      */
     public Configuration getConfiguration() {
@@ -175,6 +160,7 @@ public class Blueshift {
 
     /**
      * Checks for presence of credentials required for making api call
+     *
      * @return true if everything is OK, else false
      */
     private boolean hasValidCredentials() {
@@ -194,6 +180,7 @@ public class Blueshift {
 
     /**
      * Appending the optional user info to params
+     *
      * @param params source hash map to append details
      * @return params - updated params object
      */
@@ -224,10 +211,11 @@ public class Blueshift {
 
     /**
      * Private method that receives params and send to server using request queue.
+     *
      * @param params hash-map filled with parameters required for api call
      * @return true if everything works fine, else false
      */
-    private boolean sendEvent(HashMap<String, Object> params) {
+    private boolean sendEvent(HashMap<String, Object> params, boolean canBatchThisEvent) {
         // Check for presence of API key
         Configuration configuration = getConfiguration();
         if (configuration == null) {
@@ -283,15 +271,24 @@ public class Blueshift {
                         // adding timestamp
                         requestParams.put(BlueshiftConstants.KEY_TIMESTAMP, System.currentTimeMillis() / 1000);
 
-                        // Creating the request object.
-                        Request request = new Request();
-                        request.setPendingRetryCount(3); // setting the default retry count as 3 for all requests.
-                        request.setUrl(BlueshiftConstants.EVENT_API_URL);
-                        request.setMethod(Method.POST);
-                        request.setParamJson(new Gson().toJson(requestParams));
+                        String reqParamsJSON = new Gson().toJson(requestParams);
 
-                        // Adding the request to the queue.
-                        RequestQueue.getInstance(mContext).add(request);
+                        if (canBatchThisEvent) {
+                            Event event = new Event();
+                            event.setEventParamsJson(reqParamsJSON);
+
+                            EventsTable.getInstance(mContext).insert(event);
+                        } else {
+                            // Creating the request object.
+                            Request request = new Request();
+                            request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);
+                            request.setUrl(BlueshiftConstants.EVENT_API_URL);
+                            request.setMethod(Method.POST);
+                            request.setParamJson(reqParamsJSON);
+
+                            // Adding the request to the queue.
+                            RequestQueue.getInstance(mContext).add(request);
+                        }
 
                         return true;
                     } else {
@@ -308,29 +305,31 @@ public class Blueshift {
 
     /**
      * Method to send generic events
+     *
      * @param eventName name of the event
-     * @param params hash map with valid parameters
+     * @param params    hash map with valid parameters
      * @return true if request is successfully added to queue, els false
      */
-    public boolean trackEvent(@NotNull String eventName, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public boolean trackEvent(@NotNull String eventName, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_EVENT, eventName);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        return sendEvent(eventParams);
+        return sendEvent(eventParams, canBatchThisEvent);
     }
 
     /**
      * Method to track the campaign measurement
+     *
      * @param referrer the referrer url sent by playstore app
      */
-    public void trackAppInstall(String referrer) {
+    public void trackAppInstall(String referrer, boolean canBatchThisEvent) {
         if (TextUtils.isEmpty(referrer)) {
             Log.e(LOG_TAG, "No valid referrer url was found for the app installation.");
         } else {
-            HashMap<String, Object> utmParamsHash = new HashMap<String, Object>();
+            HashMap<String, Object> utmParamsHash = new HashMap<>();
 
             String url = Uri.decode(referrer);
             String[] paramsArray = url.split("&");
@@ -341,7 +340,7 @@ public class Blueshift {
                 }
             }
 
-            trackEvent(BlueshiftConstants.EVENT_APP_INSTALL, utmParamsHash);
+            trackEvent(BlueshiftConstants.EVENT_APP_INSTALL, utmParamsHash, canBatchThisEvent);
         }
     }
 
@@ -349,59 +348,59 @@ public class Blueshift {
      * Helps trigger identify user api call using key 'retailer_customer_id'.
      *
      * @param customerId if provided, replaces existing one (taken from UserInfo) inside request params.
-     * @param details optional additional parameters
+     * @param details    optional additional parameters
      * @return true/false based on execution of identifyUser()
      */
-    public boolean identifyUserByCustomerId(String customerId, HashMap<String, Object> details) {
+    public boolean identifyUserByCustomerId(String customerId, HashMap<String, Object> details, boolean canBatchThisEvent) {
         if (TextUtils.isEmpty(customerId)) {
             Log.w(LOG_TAG, "identifyUserByCustomerId() - The retailer customer ID provided is empty.");
         }
 
-        return identifyUser(BlueshiftConstants.KEY_RETAILER_CUSTOMER_ID, customerId, details);
+        return identifyUser(BlueshiftConstants.KEY_RETAILER_CUSTOMER_ID, customerId, details, canBatchThisEvent);
     }
 
     /**
      * Helps trigger identify user api call using key 'device_identifier'.
      *
      * @param androidAdId android ad id provided by host/customer app.
-     * @param details optional additional parameters
+     * @param details     optional additional parameters
      * @return true/false based on execution of identifyUser()
      */
-    public boolean identifyUserByDeviceId(String androidAdId, HashMap<String, Object> details) {
+    public boolean identifyUserByDeviceId(String androidAdId, HashMap<String, Object> details, boolean canBatchThisEvent) {
         if (TextUtils.isEmpty(androidAdId)) {
             Log.w(LOG_TAG, "identifyUserByAdId() - The Android Ad ID provided is empty.");
         }
 
-        return identifyUser(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, androidAdId, details);
+        return identifyUser(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, androidAdId, details, canBatchThisEvent);
     }
 
     /**
      * Helps trigger identify user api call using key 'email'.
      *
-     * @param email registered email address provided by host/customer app
+     * @param email   registered email address provided by host/customer app
      * @param details optional additional parameters
      * @return true/false based on execution of identifyUser()
      */
-    public boolean identifyUserByEmail(String email, HashMap<String, Object> details) {
+    public boolean identifyUserByEmail(String email, HashMap<String, Object> details, boolean canBatchThisEvent) {
         if (email == null || email.isEmpty() || !(android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches())) {
             Log.w(LOG_TAG, "identifyUserByEmail() - The email address provided is invalid.");
         }
 
-        return identifyUser(BlueshiftConstants.KEY_EMAIL, email, details);
+        return identifyUser(BlueshiftConstants.KEY_EMAIL, email, details, canBatchThisEvent);
     }
 
     /**
      * Triggers identify user api call. If either key or value is null or empty,
      * that key value pair will be  ignored.
      *
-     * @param key the key used for identify user. Ex: email, device_identifier, retailer_customer_id
-     * @param value the corresponding value for 'key'
+     * @param key     the key used for identify user. Ex: email, device_identifier, retailer_customer_id
+     * @param value   the corresponding value for 'key'
      * @param details optional additional parameters
      * @return true if trackEvent is success, false if valid credentials are unavailable or trackEvent fails.
      */
-    public boolean identifyUser(String key, String value, HashMap<String, Object> details) {
+    public boolean identifyUser(String key, String value, HashMap<String, Object> details, boolean canBatchThisEvent) {
         if (hasValidCredentials()) {
-            HashMap<String, Object> userParams = new HashMap<String, Object>();
+            HashMap<String, Object> userParams = new HashMap<>();
 
             if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
                 userParams.put(key, value);
@@ -411,7 +410,7 @@ public class Blueshift {
                 userParams.putAll(details);
             }
 
-            return trackEvent(BlueshiftConstants.EVENT_IDENTIFY, userParams);
+            return trackEvent(BlueshiftConstants.EVENT_IDENTIFY, userParams, canBatchThisEvent);
 
         } else {
             Log.e(LOG_TAG, "Error (identifyUser) : Basic credentials validation failed.");
@@ -419,64 +418,63 @@ public class Blueshift {
         }
     }
 
-    public void trackScreenView(Activity activity) {
+    public void trackScreenView(Activity activity, boolean canBatchThisEvent) {
         if (activity != null) {
-            trackScreenView(activity.getClass().getSimpleName());
+            trackScreenView(activity.getClass().getSimpleName(), canBatchThisEvent);
         }
     }
 
-    public void trackScreenView(String screenName) {
-        HashMap<String, Object> userParams = new HashMap<String, Object>();
+    public void trackScreenView(String screenName, boolean canBatchThisEvent) {
+        HashMap<String, Object> userParams = new HashMap<>();
         userParams.put(BlueshiftConstants.KEY_SCREEN_VIEWED, screenName);
 
-        trackEvent(BlueshiftConstants.EVENT_PAGE_LOAD, userParams);
+        trackEvent(BlueshiftConstants.EVENT_PAGE_LOAD, userParams, canBatchThisEvent);
     }
 
-    public void trackAppOpen() {
-        trackAppOpen(null);
+    public void trackAppOpen(boolean canBatchThisEvent) {
+        trackAppOpen(null, canBatchThisEvent);
     }
 
-    public void trackAppOpen(HashMap<String, Object> params) {
-        trackEvent(BlueshiftConstants.EVENT_APP_OPEN, params);
+    public void trackAppOpen(HashMap<String, Object> params, boolean canBatchThisEvent) {
+        trackEvent(BlueshiftConstants.EVENT_APP_OPEN, params, canBatchThisEvent);
     }
 
-    public void trackProductView(String sku, int categoryId) {
-        trackProductView(sku, categoryId, null);
+    public void trackProductView(String sku, int categoryId, boolean canBatchThisEvent) {
+        trackProductView(sku, categoryId, null, canBatchThisEvent);
     }
 
-    public void trackProductView(String sku, int categoryId, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackProductView(String sku, int categoryId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_SKU, sku);
         eventParams.put(BlueshiftConstants.KEY_CATEGORY_ID, categoryId);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_VIEW, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_VIEW, eventParams, canBatchThisEvent);
     }
 
-    public void trackAddToCart(String sku, int quantity) {
-        trackAddToCart(sku, quantity, null);
+    public void trackAddToCart(String sku, int quantity, boolean canBatchThisEvent) {
+        trackAddToCart(sku, quantity, null, canBatchThisEvent);
     }
 
-    public void trackAddToCart(String sku, int quantity, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackAddToCart(String sku, int quantity, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_SKU, sku);
         eventParams.put(BlueshiftConstants.KEY_QUANTITY, quantity);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_ADD_TO_CART, eventParams);
-
+        trackEvent(BlueshiftConstants.EVENT_ADD_TO_CART, eventParams, canBatchThisEvent);
     }
 
-    public void trackCheckoutCart(Product[] products, float revenue, float discount, String coupon) {
-        trackCheckoutCart(products, revenue, discount, coupon, null);
+    public void trackCheckoutCart(Product[] products, float revenue, float discount, String coupon, boolean canBatchThisEvent) {
+        trackCheckoutCart(products, revenue, discount, coupon, null, canBatchThisEvent);
     }
 
-    public void trackCheckoutCart(Product[] products, float revenue, float discount, String coupon, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackCheckoutCart(Product[] products, float revenue, float discount, String coupon, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_PRODUCTS, products);
         eventParams.put(BlueshiftConstants.KEY_REVENUE, revenue);
         eventParams.put(BlueshiftConstants.KEY_DISCOUNT, discount);
@@ -485,15 +483,15 @@ public class Blueshift {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_CHECKOUT, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_CHECKOUT, eventParams, canBatchThisEvent);
     }
 
-    public void trackProductsPurchase(String orderId, Product[] products, float revenue, float shippingCost, float discount, String coupon) {
-        trackProductsPurchase(orderId, products, revenue, shippingCost, discount, coupon, null);
+    public void trackProductsPurchase(String orderId, Product[] products, float revenue, float shippingCost, float discount, String coupon, boolean canBatchThisEvent) {
+        trackProductsPurchase(orderId, products, revenue, shippingCost, discount, coupon, null, canBatchThisEvent);
     }
 
-    public void trackProductsPurchase(String orderId, Product[] products, float revenue, float shippingCost, float discount, String coupon, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackProductsPurchase(String orderId, Product[] products, float revenue, float shippingCost, float discount, String coupon, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_ORDER_ID, orderId);
         eventParams.put(BlueshiftConstants.KEY_PRODUCTS, products);
         eventParams.put(BlueshiftConstants.KEY_REVENUE, revenue);
@@ -504,48 +502,48 @@ public class Blueshift {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_PURCHASE, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_PURCHASE, eventParams, canBatchThisEvent);
     }
 
-    public void trackPurchaseCancel(String orderId) {
-        trackPurchaseCancel(orderId, null);
+    public void trackPurchaseCancel(String orderId, boolean canBatchThisEvent) {
+        trackPurchaseCancel(orderId, null, canBatchThisEvent);
     }
 
-    public void trackPurchaseCancel(String orderId, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackPurchaseCancel(String orderId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_ORDER_ID, orderId);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_CANCEL, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_CANCEL, eventParams, canBatchThisEvent);
     }
 
-    public void trackPurchaseReturn(String orderId, Product[] products) {
-        trackPurchaseReturn(orderId, products, null);
+    public void trackPurchaseReturn(String orderId, Product[] products, boolean canBatchThisEvent) {
+        trackPurchaseReturn(orderId, products, null, canBatchThisEvent);
     }
 
-    public void trackPurchaseReturn(String orderId, Product[] products, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackPurchaseReturn(String orderId, Product[] products, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_ORDER_ID, orderId);
         eventParams.put(BlueshiftConstants.KEY_PRODUCTS, products);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_RETURN, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_RETURN, eventParams, canBatchThisEvent);
     }
 
-    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query) {
-        trackProductSearch(skus, numberOfResults, pageNumber, query, null);
+    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query, boolean canBatchThisEvent) {
+        trackProductSearch(skus, numberOfResults, pageNumber, query, null, canBatchThisEvent);
     }
 
-    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query, HashMap<String, Object> filters) {
-        trackProductSearch(skus, numberOfResults, pageNumber, query, filters, null);
+    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query, HashMap<String, Object> filters, boolean canBatchThisEvent) {
+        trackProductSearch(skus, numberOfResults, pageNumber, query, filters, null, canBatchThisEvent);
     }
 
-    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query, HashMap<String, Object> filters, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackProductSearch(String[] skus, int numberOfResults, int pageNumber, String query, HashMap<String, Object> filters, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_SKUS, skus);
         eventParams.put(BlueshiftConstants.KEY_NUMBER_OF_RESULTS, numberOfResults);
         eventParams.put(BlueshiftConstants.KEY_PAGE_NUMBER, pageNumber);
@@ -555,42 +553,42 @@ public class Blueshift {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_SEARCH, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_SEARCH, eventParams, canBatchThisEvent);
     }
 
-    public void trackEmailListSubscription(String email) {
-        trackEmailListSubscription(email, null);
+    public void trackEmailListSubscription(String email, boolean canBatchThisEvent) {
+        trackEmailListSubscription(email, null, canBatchThisEvent);
     }
 
-    public void trackEmailListSubscription(String email, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackEmailListSubscription(String email, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_EMAIL, email);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_SUBSCRIBE, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_SUBSCRIBE, eventParams, canBatchThisEvent);
     }
 
-    public void trackEmailListUnsubscription(String email) {
-        trackEmailListUnsubscription(email, null);
+    public void trackEmailListUnsubscription(String email, boolean canBatchThisEvent) {
+        trackEmailListUnsubscription(email, null, canBatchThisEvent);
     }
 
-    public void trackEmailListUnsubscription(String email, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackEmailListUnsubscription(String email, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_EMAIL, email);
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_UNSUBSCRIBE, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_UNSUBSCRIBE, eventParams, canBatchThisEvent);
     }
 
-    public boolean trackSubscriptionInitialization(SubscriptionState subscriptionState, String cycleType, int cycleLength, String subscriptionType, float price, long startDate) {
-        return trackSubscriptionInitialization(subscriptionState, cycleType, cycleLength, subscriptionType, price, startDate, null);
+    public boolean trackSubscriptionInitialization(SubscriptionState subscriptionState, String cycleType, int cycleLength, String subscriptionType, float price, long startDate, boolean canBatchThisEvent) {
+        return trackSubscriptionInitialization(subscriptionState, cycleType, cycleLength, subscriptionType, price, startDate, null, canBatchThisEvent);
     }
 
-    public boolean trackSubscriptionInitialization(SubscriptionState subscriptionState, String cycleType, int cycleLength, @NotNull String subscriptionType, float price, long startDate, HashMap<String, Object> params) {
+    public boolean trackSubscriptionInitialization(SubscriptionState subscriptionState, String cycleType, int cycleLength, @NotNull String subscriptionType, float price, long startDate, HashMap<String, Object> params, boolean canBatchThisEvent) {
         Subscription subscription = Subscription.getInstance(mContext);
         subscription.setSubscriptionState(subscriptionState);
         subscription.setCycleType(cycleType);
@@ -601,7 +599,7 @@ public class Blueshift {
         subscription.setParams(params);
         subscription.save(mContext);
 
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_TYPE, cycleType);
         eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_LENGTH, cycleLength);
         eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PLAN_TYPE, subscriptionType);
@@ -616,10 +614,10 @@ public class Blueshift {
             switch (subscriptionState) {
                 case START:
                 case UPGRADE:
-                    return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_UPGRADE, eventParams);
+                    return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_UPGRADE, eventParams, canBatchThisEvent);
 
                 case DOWNGRADE:
-                    return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_DOWNGRADE, eventParams);
+                    return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_DOWNGRADE, eventParams, canBatchThisEvent);
 
                 default:
                     return false;
@@ -629,14 +627,14 @@ public class Blueshift {
         return false;
     }
 
-    public boolean trackSubscriptionPause() {
-        return trackSubscriptionPause(null);
+    public boolean trackSubscriptionPause(boolean canBatchThisEvent) {
+        return trackSubscriptionPause(null, canBatchThisEvent);
     }
 
-    public boolean trackSubscriptionPause(HashMap<String, Object> params) {
+    public boolean trackSubscriptionPause(HashMap<String, Object> params, boolean canBatchThisEvent) {
         Subscription subscription = Subscription.getInstance(mContext);
         if (subscription.hasValidSubscription()) {
-            HashMap<String, Object> eventParams = new HashMap<String, Object>();
+            HashMap<String, Object> eventParams = new HashMap<>();
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PLAN_TYPE, subscription.getSubscriptionType());
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_TYPE, subscription.getCycleType());
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_LENGTH, subscription.getCycleLength());
@@ -647,21 +645,21 @@ public class Blueshift {
                 eventParams.putAll(params);
             }
 
-            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_DOWNGRADE, eventParams);
+            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_DOWNGRADE, eventParams, canBatchThisEvent);
         } else {
             Log.e(LOG_TAG, "No valid subscription was found to pause.");
             return false;
         }
     }
 
-    public boolean trackSubscriptionUnpause() {
-        return trackSubscriptionUnpause(null);
+    public boolean trackSubscriptionUnpause(boolean canBatchThisEvent) {
+        return trackSubscriptionUnpause(null, canBatchThisEvent);
     }
 
-    public boolean trackSubscriptionUnpause(HashMap<String, Object> params) {
+    public boolean trackSubscriptionUnpause(HashMap<String, Object> params, boolean canBatchThisEvent) {
         Subscription subscription = Subscription.getInstance(mContext);
         if (subscription.hasValidSubscription()) {
-            HashMap<String, Object> eventParams = new HashMap<String, Object>();
+            HashMap<String, Object> eventParams = new HashMap<>();
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PLAN_TYPE, subscription.getSubscriptionType());
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_TYPE, subscription.getCycleType());
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PERIOD_LENGTH, subscription.getCycleLength());
@@ -672,21 +670,21 @@ public class Blueshift {
                 eventParams.putAll(params);
             }
 
-            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_UPGRADE, eventParams);
+            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_UPGRADE, eventParams, canBatchThisEvent);
         } else {
             Log.e(LOG_TAG, "No valid subscription was found to unpause.");
             return false;
         }
     }
 
-    public boolean trackSubscriptionCancel() {
-        return trackSubscriptionCancel(null);
+    public boolean trackSubscriptionCancel(boolean canBatchThisEvent) {
+        return trackSubscriptionCancel(null, canBatchThisEvent);
     }
 
-    public boolean trackSubscriptionCancel(HashMap<String, Object> params) {
+    public boolean trackSubscriptionCancel(HashMap<String, Object> params, boolean canBatchThisEvent) {
         Subscription subscription = Subscription.getInstance(mContext);
         if (subscription.hasValidSubscription()) {
-            HashMap<String, Object> eventParams = new HashMap<String, Object>();
+            HashMap<String, Object> eventParams = new HashMap<>();
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_PLAN_TYPE, subscription.getSubscriptionType());
             eventParams.put(BlueshiftConstants.KEY_SUBSCRIPTION_STATUS, BlueshiftConstants.STATUS_CANCELED);
 
@@ -694,55 +692,80 @@ public class Blueshift {
                 eventParams.putAll(params);
             }
 
-            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_CANCEL, eventParams);
+            return trackEvent(BlueshiftConstants.EVENT_SUBSCRIPTION_CANCEL, eventParams, canBatchThisEvent);
         } else {
             Log.e(LOG_TAG, "No valid subscription was found to cancel.");
             return false;
         }
     }
 
-    public void trackNotificationView(String notificationId) {
-        trackNotificationView(notificationId, null);
+    public void trackNotificationView(String notificationId, boolean canBatchThisEvent) {
+        trackNotificationView(notificationId, null, canBatchThisEvent);
     }
 
-    public void trackNotificationView(String notificationId,  HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackNotificationView(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_PUSH_VIEW, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_PUSH_VIEW, eventParams, canBatchThisEvent);
     }
 
-    public void trackNotificationClick(String notificationId) {
-        trackNotificationClick(notificationId, null);
+    public void trackNotificationClick(String notificationId, boolean canBatchThisEvent) {
+        trackNotificationClick(notificationId, null, canBatchThisEvent);
     }
 
-    public void trackNotificationClick(String notificationId, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackNotificationClick(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_PUSH_CLICK, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_PUSH_CLICK, eventParams, canBatchThisEvent);
     }
 
-    public void trackNotificationPageOpen(String notificationId) {
-        trackNotificationPageOpen(notificationId, null);
+    public void trackNotificationPageOpen(String notificationId, boolean canBatchThisEvent) {
+        trackNotificationPageOpen(notificationId, null, canBatchThisEvent);
     }
 
-    public void trackNotificationPageOpen(String notificationId, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<String, Object>();
+    public void trackNotificationPageOpen(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
         eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
         }
 
-        trackEvent(BlueshiftConstants.EVENT_APP_OPEN, eventParams);
+        trackEvent(BlueshiftConstants.EVENT_APP_OPEN, eventParams, canBatchThisEvent);
+    }
+
+    /**
+     * Updates the mDeviceParams with advertising ID
+     */
+    private class FetchAndUpdateAdIdTask extends AsyncTask<Void, Void, String> {
+
+        @Override
+        protected void onPreExecute() {
+            Log.d(LOG_TAG, "Trying to fetch AdvertisingId");
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            return DeviceUtils.getAdvertisingID(mContext);
+        }
+
+        @Override
+        protected void onPostExecute(String adId) {
+            if (!TextUtils.isEmpty(adId)) {
+                mDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, adId);
+            } else {
+                Log.d(LOG_TAG, "Could not fetch AdvertisingId");
+            }
+        }
     }
 }

--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -319,12 +319,18 @@ public class Blueshift {
         }
 
         // running on a non-UI thread to avoid possible ANR.
-        new Thread(new Runnable() {
+        new AsyncTask<Void, Void, Boolean>() {
             @Override
-            public void run() {
-                sendEvent(eventParams, canBatchThisEvent);
+            protected Boolean doInBackground(Void... params) {
+                // call send event and return its result.
+                return sendEvent(eventParams, canBatchThisEvent);
             }
-        }).run();
+
+            @Override
+            protected void onPostExecute(Boolean isSuccess) {
+                Log.d(LOG_TAG, "Event creation " + (isSuccess ? "success." : "failed."));
+            }
+        };
     }
 
     /**

--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -330,7 +330,7 @@ public class Blueshift {
             protected void onPostExecute(Boolean isSuccess) {
                 Log.d(LOG_TAG, "Event creation " + (isSuccess ? "success." : "failed."));
             }
-        };
+        }.execute();
     }
 
     /**

--- a/library/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/library/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -8,8 +8,9 @@ public class BlueshiftConstants {
     /**
      * URLs for server communication
      */
-    public static final String BASE_URL = "https://api.getblueshift.com";
-    public static final String EVENT_API_URL = BASE_URL + "/api/v1/event";
+    public static final String BASE_URL = "https://api.getblueshift.com/api/v1";
+    public static final String EVENT_API_URL = BASE_URL + "/event";
+    public static final String BULK_EVENT_API_URL = BASE_URL + "/bulkevents";
 
     /**
      * Event names sent to Blueshift server
@@ -94,4 +95,9 @@ public class BlueshiftConstants {
     public static final String STATUS_PAUSED = "paused";
     public static final String STATUS_ACTIVE = "active";
     public static final String STATUS_CANCELED = "canceled";
+
+    /**
+     * Bulk Event
+     */
+    public static final int BULK_EVENT_PAGE_SIZE = 100;
 }

--- a/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
+++ b/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
@@ -1,0 +1,64 @@
+package com.blueshift.batch;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.blueshift.BlueshiftConstants;
+import com.blueshift.httpmanager.Method;
+import com.blueshift.httpmanager.Request;
+import com.blueshift.httpmanager.request_queue.RequestQueue;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+/**
+ * Created by rahul on 25/8/16.
+ * <p/>
+ * This class receives the alarm manager's trigger.
+ * It will be creating a new batch and sending it to request queue.
+ * The integrating app should add this in their AndroidManifest.xml as,
+ * <receiver android:name="com.blueshift.batch.AlarmReceiver"/>
+ */
+public class AlarmReceiver extends BroadcastReceiver {
+
+    private static final String LOG_TAG = AlarmReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        FailedEventsTable failedEventsTable = FailedEventsTable.getInstance(context);
+        ArrayList<String> bulkEventsApiParams = failedEventsTable.getBulkEventParameters(BlueshiftConstants.BULK_EVENT_PAGE_SIZE);
+
+        int spaceAvailableInBatch = BlueshiftConstants.BULK_EVENT_PAGE_SIZE - bulkEventsApiParams.size();
+
+        if (spaceAvailableInBatch > 0) {
+            // there is space for some more events. Take it from Events table.
+            EventsTable eventsTable = EventsTable.getInstance(context);
+            ArrayList<String> eventParams = eventsTable.getBulkEventParameters(spaceAvailableInBatch);
+            bulkEventsApiParams.addAll(eventParams);
+        }
+
+        if (bulkEventsApiParams.size() > 0) {
+            try {
+                JSONObject reqParams = new JSONObject();
+                reqParams.put("events", bulkEventsApiParams);
+
+                // Creating the request object.
+                Request request = new Request();
+                request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);
+                request.setUrl(BlueshiftConstants.BULK_EVENT_API_URL);
+                request.setMethod(Method.POST);
+                request.setParamJson(reqParams.toString());
+
+                // Adding the request to the queue.
+                RequestQueue.getInstance(context).add(request);
+            } catch (JSONException e) {
+                Log.e(LOG_TAG, "Invalid JSON. " + e.getMessage());
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
+++ b/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
@@ -9,11 +9,10 @@ import com.blueshift.BlueshiftConstants;
 import com.blueshift.httpmanager.Method;
 import com.blueshift.httpmanager.Request;
 import com.blueshift.httpmanager.request_queue.RequestQueue;
-
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.google.gson.Gson;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Created by rahul on 25/8/16.
@@ -31,34 +30,35 @@ public class AlarmReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
 
         FailedEventsTable failedEventsTable = FailedEventsTable.getInstance(context);
-        ArrayList<String> bulkEventsApiParams = failedEventsTable.getBulkEventParameters(BlueshiftConstants.BULK_EVENT_PAGE_SIZE);
+        ArrayList<HashMap<String, Object>> bulkEventsApiParams = failedEventsTable.getBulkEventParameters(BlueshiftConstants.BULK_EVENT_PAGE_SIZE);
+
+        Log.d(LOG_TAG, "Found " + bulkEventsApiParams.size() + " items inside failed events table.");
 
         int spaceAvailableInBatch = BlueshiftConstants.BULK_EVENT_PAGE_SIZE - bulkEventsApiParams.size();
 
         if (spaceAvailableInBatch > 0) {
             // there is space for some more events. Take it from Events table.
             EventsTable eventsTable = EventsTable.getInstance(context);
-            ArrayList<String> eventParams = eventsTable.getBulkEventParameters(spaceAvailableInBatch);
+            ArrayList<HashMap<String, Object>> eventParams = eventsTable.getBulkEventParameters(spaceAvailableInBatch);
+
+            Log.d(LOG_TAG, "Found " + eventParams.size() + " items inside batch events table.");
+
             bulkEventsApiParams.addAll(eventParams);
         }
 
         if (bulkEventsApiParams.size() > 0) {
-            try {
-                JSONObject reqParams = new JSONObject();
-                reqParams.put("events", bulkEventsApiParams);
+            BulkEvent bulkEvent = new BulkEvent();
+            bulkEvent.setEvents(bulkEventsApiParams);
 
-                // Creating the request object.
-                Request request = new Request();
-                request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);
-                request.setUrl(BlueshiftConstants.BULK_EVENT_API_URL);
-                request.setMethod(Method.POST);
-                request.setParamJson(reqParams.toString());
+            // Creating the request object.
+            Request request = new Request();
+            request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);
+            request.setUrl(BlueshiftConstants.BULK_EVENT_API_URL);
+            request.setMethod(Method.POST);
+            request.setParamJson(new Gson().toJson(bulkEvent));
 
-                // Adding the request to the queue.
-                RequestQueue.getInstance(context).add(request);
-            } catch (JSONException e) {
-                Log.e(LOG_TAG, "Invalid JSON. " + e.getMessage());
-            }
+            // Adding the request to the queue.
+            RequestQueue.getInstance(context).add(request);
         }
     }
 }

--- a/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
+++ b/library/src/main/java/com/blueshift/batch/AlarmReceiver.java
@@ -29,10 +29,12 @@ public class AlarmReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
 
+        // Log.d(LOG_TAG, "Received alarm for batch creation.");
+
         FailedEventsTable failedEventsTable = FailedEventsTable.getInstance(context);
         ArrayList<HashMap<String, Object>> bulkEventsApiParams = failedEventsTable.getBulkEventParameters(BlueshiftConstants.BULK_EVENT_PAGE_SIZE);
 
-        Log.d(LOG_TAG, "Found " + bulkEventsApiParams.size() + " items inside failed events table.");
+        // Log.d(LOG_TAG, "Found " + bulkEventsApiParams.size() + " items inside failed events table.");
 
         int spaceAvailableInBatch = BlueshiftConstants.BULK_EVENT_PAGE_SIZE - bulkEventsApiParams.size();
 
@@ -41,7 +43,7 @@ public class AlarmReceiver extends BroadcastReceiver {
             EventsTable eventsTable = EventsTable.getInstance(context);
             ArrayList<HashMap<String, Object>> eventParams = eventsTable.getBulkEventParameters(spaceAvailableInBatch);
 
-            Log.d(LOG_TAG, "Found " + eventParams.size() + " items inside batch events table.");
+            // Log.d(LOG_TAG, "Found " + eventParams.size() + " items inside batch events table.");
 
             bulkEventsApiParams.addAll(eventParams);
         }

--- a/library/src/main/java/com/blueshift/batch/BulkEvent.java
+++ b/library/src/main/java/com/blueshift/batch/BulkEvent.java
@@ -1,0 +1,15 @@
+package com.blueshift.batch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Created by rahul on 26/8/16.
+ */
+public class BulkEvent {
+    ArrayList<HashMap<String,Object>> events;
+
+    public void setEvents(ArrayList<HashMap<String,Object>> events) {
+        this.events = events;
+    }
+}

--- a/library/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/library/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -9,6 +9,8 @@ import android.util.Log;
 import com.blueshift.Blueshift;
 import com.blueshift.model.Configuration;
 
+import java.text.SimpleDateFormat;
+
 /**
  * Created by rahul on 25/8/16.
  */
@@ -16,19 +18,24 @@ public class BulkEventManager {
 
     private static final String LOG_TAG = BulkEventManager.class.getSimpleName();
 
-    private static PendingIntent getAlarmIntent(Context context) {
+    private static PendingIntent getAlarmPendingIntent(Context context, int flag) {
         Intent alarmIntent = new Intent(context, AlarmReceiver.class);
-        return PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(context, 0, alarmIntent, flag);
     }
 
     public static void startAlarmManager(Context context) {
+        // Log.d(LOG_TAG, "Starting alarm service");
+
+        // stop alarm manager if it is already running
+        stopAlarmManager(context);
+
         Configuration configuration = Blueshift.getInstance(context).getConfiguration();
         if (configuration == null) {
             Log.e(LOG_TAG, "Please initialize the SDK. Call initialize() method with a valid configuration object.");
         } else {
             long interval = configuration.getBatchInterval();
 
-            Log.d(LOG_TAG, "Bulk event time interval: " + interval + "ms");
+            Log.d(LOG_TAG, "Bulk event time interval: " + (interval / 1000f) / 60f + " min.");
 
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             if (alarmManager != null) {
@@ -36,18 +43,25 @@ public class BulkEventManager {
                         AlarmManager.ELAPSED_REALTIME,
                         interval, // start in interval time from now.
                         interval, // repeat every interval time.
-                        getAlarmIntent(context)
+                        getAlarmPendingIntent(context, PendingIntent.FLAG_UPDATE_CURRENT)
                 );
             }
         }
     }
 
     public static void stopAlarmManager(Context context) {
-        PendingIntent alarmIntent = getAlarmIntent(context);
+        // FLAG_NO_CREATE: if described PendingIntent does not already exist,
+        // then simply return null instead of creating it.
+        PendingIntent alarmIntent = getAlarmPendingIntent(context, PendingIntent.FLAG_NO_CREATE);
         if (alarmIntent != null) {
+            Log.d(LOG_TAG, "Found an existing alarm. Cancelling it.");
+
+            // we have an intent in alarm manager.
             AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             if (alarmManager != null) {
+                // cancel alarm
                 alarmManager.cancel(alarmIntent);
+                // cancel pending intent
                 alarmIntent.cancel();
             }
         }

--- a/library/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/library/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -1,0 +1,55 @@
+package com.blueshift.batch;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.blueshift.Blueshift;
+import com.blueshift.model.Configuration;
+
+/**
+ * Created by rahul on 25/8/16.
+ */
+public class BulkEventManager {
+
+    private static final String LOG_TAG = BulkEventManager.class.getSimpleName();
+
+    private static PendingIntent getAlarmIntent(Context context) {
+        Intent alarmIntent = new Intent(context, AlarmReceiver.class);
+        return PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    public static void startAlarmManager(Context context) {
+        Configuration configuration = Blueshift.getInstance(context).getConfiguration();
+        if (configuration == null) {
+            Log.e(LOG_TAG, "Please initialize the SDK. Call initialize() method with a valid configuration object.");
+        } else {
+            long interval = configuration.getBatchInterval();
+
+            Log.d(LOG_TAG, "Bulk event time interval: " + interval + "ms");
+
+            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            if (alarmManager != null) {
+                alarmManager.setInexactRepeating(
+                        AlarmManager.ELAPSED_REALTIME,
+                        interval, // start in interval time from now.
+                        interval, // repeat every interval time.
+                        getAlarmIntent(context)
+                );
+            }
+        }
+    }
+
+    public static void stopAlarmManager(Context context) {
+        PendingIntent alarmIntent = getAlarmIntent(context);
+        if (alarmIntent != null) {
+            AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            if (alarmManager != null) {
+                alarmManager.cancel(alarmIntent);
+                alarmIntent.cancel();
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/blueshift/batch/Event.java
+++ b/library/src/main/java/com/blueshift/batch/Event.java
@@ -1,11 +1,15 @@
 package com.blueshift.batch;
 
+import com.google.gson.Gson;
+
+import java.util.HashMap;
+
 /**
  * Created by rahul on 24/8/16.
  */
 public class Event {
     private long mId;
-    private String mEventParamsJson;
+    private HashMap<String, Object> mEventParams;
 
     public long getId() {
         return mId;
@@ -15,11 +19,15 @@ public class Event {
         mId = id;
     }
 
-    public String getEventParamsJson() {
-        return mEventParamsJson;
+    public HashMap<String, Object> getEventParams() {
+        return mEventParams;
     }
 
-    public void setEventParamsJson(String eventParamsJson) {
-        mEventParamsJson = eventParamsJson;
+    public String getEventParamsJson() {
+        return new Gson().toJson(mEventParams);
+    }
+
+    public void setEventParams(HashMap<String, Object> eventParamsJson) {
+        mEventParams = eventParamsJson;
     }
 }

--- a/library/src/main/java/com/blueshift/batch/EventsTable.java
+++ b/library/src/main/java/com/blueshift/batch/EventsTable.java
@@ -3,9 +3,11 @@ package com.blueshift.batch;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.blueshift.framework.BaseSqliteTable;
+import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +48,13 @@ public class EventsTable extends BaseSqliteTable<Event> {
 
         if (cursor != null && !cursor.isAfterLast()) {
             event.setId(cursor.getLong(cursor.getColumnIndex(FIELD_ID)));
-            event.setEventParamsJson(cursor.getString(cursor.getColumnIndex(FIELD_EVENT_PARAMS_JSON)));
+
+            String json = cursor.getString(cursor.getColumnIndex(FIELD_EVENT_PARAMS_JSON));
+            HashMap<String, Object> paramsMap = new HashMap<>();
+            if (!TextUtils.isEmpty(json)) {
+                paramsMap = new Gson().fromJson(json, paramsMap.getClass());
+            }
+            event.setEventParams(paramsMap);
         }
 
         return event;
@@ -86,8 +94,8 @@ public class EventsTable extends BaseSqliteTable<Event> {
      *
      * @return array of event request parameter JSONs
      */
-    public ArrayList<String> getBulkEventParameters(int batchSize) {
-        ArrayList<String> result = new ArrayList<>();
+    public ArrayList<HashMap<String,Object>> getBulkEventParameters(int batchSize) {
+        ArrayList<HashMap<String,Object>> result = new ArrayList<>();
 
         ArrayList<Event> events = findWithLimit(batchSize);
         if (events.size() > 0) {
@@ -95,7 +103,7 @@ public class EventsTable extends BaseSqliteTable<Event> {
 
             for (Event event : events) {
                 // get the event parameter
-                result.add(event.getEventParamsJson());
+                result.add(event.getEventParams());
 
                 // get id for deleting the item.
                 idList.add(String.valueOf(event.getId()));

--- a/library/src/main/java/com/blueshift/batch/FailedEventsTable.java
+++ b/library/src/main/java/com/blueshift/batch/FailedEventsTable.java
@@ -3,9 +3,11 @@ package com.blueshift.batch;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.blueshift.framework.BaseSqliteTable;
+import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,7 +53,13 @@ public class FailedEventsTable extends BaseSqliteTable<Event> {
 
         if (cursor != null && !cursor.isAfterLast()) {
             event.setId(cursor.getLong(cursor.getColumnIndex(FIELD_ID)));
-            event.setEventParamsJson(cursor.getString(cursor.getColumnIndex(FIELD_EVENT_PARAMS_JSON)));
+
+            String json = cursor.getString(cursor.getColumnIndex(FIELD_EVENT_PARAMS_JSON));
+            HashMap<String, Object> paramsMap = new HashMap<>();
+            if (!TextUtils.isEmpty(json)) {
+                paramsMap = new Gson().fromJson(json, paramsMap.getClass());
+            }
+            event.setEventParams(paramsMap);
         }
 
         return event;
@@ -91,8 +99,8 @@ public class FailedEventsTable extends BaseSqliteTable<Event> {
      *
      * @return array of event request parameter JSONs
      */
-    public ArrayList<String> getBulkEventParameters(int batchSize) {
-        ArrayList<String> result = new ArrayList<>();
+    public ArrayList<HashMap<String,Object>> getBulkEventParameters(int batchSize) {
+        ArrayList<HashMap<String,Object>> result = new ArrayList<>();
 
         ArrayList<Event> events = findWithLimit(batchSize);
         if (events.size() > 0) {
@@ -100,7 +108,7 @@ public class FailedEventsTable extends BaseSqliteTable<Event> {
 
             for (Event event : events) {
                 // get the event parameter
-                result.add(event.getEventParamsJson());
+                result.add(event.getEventParams());
 
                 // get id for deleting the item.
                 idList.add(String.valueOf(event.getId()));

--- a/library/src/main/java/com/blueshift/httpmanager/HTTPManager.java
+++ b/library/src/main/java/com/blueshift/httpmanager/HTTPManager.java
@@ -52,7 +52,7 @@ public class HTTPManager {
         mIgnoreHostnameVerification = false;
         mAuthToken = null;
 
-        addRequestProperty("User-Agent", "Mozilla/five.0 ( compatible ) ");
+        addRequestProperty("User-Agent", System.getProperty("http.agent"));
         addRequestProperty("Accept", "application/json");
         addRequestProperty("Connection", "close");
     }

--- a/library/src/main/java/com/blueshift/model/Configuration.java
+++ b/library/src/main/java/com/blueshift/model/Configuration.java
@@ -1,5 +1,7 @@
 package com.blueshift.model;
 
+import android.app.AlarmManager;
+
 /**
  * Created by rahul on 19/2/15.
  */
@@ -9,6 +11,11 @@ public class Configuration {
     Class cartPage;
     Class offerDisplayPage;
     String apiKey;
+    long batchInterval;
+
+    public Configuration() {
+        batchInterval = AlarmManager.INTERVAL_HALF_HOUR;
+    }
 
     public int getAppIcon() {
         return appIcon;
@@ -48,5 +55,19 @@ public class Configuration {
 
     public void setOfferDisplayPage(Class offerDisplayPage) {
         this.offerDisplayPage = offerDisplayPage;
+    }
+
+    public long getBatchInterval() {
+        return batchInterval;
+    }
+
+    /**
+     * Set interval between bulk event api calls here.
+     * Default value is AlarmManager.INTERVAL_HALF_HOUR
+     *
+     * @param batchInterval batch interval in milliseconds
+     */
+    public void setBatchInterval(long batchInterval) {
+        this.batchInterval = batchInterval;
     }
 }

--- a/library/src/main/java/com/blueshift/receiver/AppInstallReceiver.java
+++ b/library/src/main/java/com/blueshift/receiver/AppInstallReceiver.java
@@ -20,7 +20,8 @@ public class AppInstallReceiver extends BroadcastReceiver {
         if (extras != null && extras.keySet().contains("referrer")) {
             String referrer = intent.getExtras().getString("referrer");
             if (referrer != null) {
-                Blueshift.getInstance(context).trackAppInstall(referrer);
+                // events sent by SDK are always batched.
+                Blueshift.getInstance(context).trackAppInstall(referrer, true);
             } else {
                 Log.w(LOG_TAG, "The referrer url parameters are not found in the INSTALL_REFERRER broadcast message.");
             }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -32,7 +32,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                     (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.cancel(intent.getIntExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, 0));
 
-            Blueshift.getInstance(context).trackNotificationClick(message.getId());
+            Blueshift.getInstance(context).trackNotificationClick(message.getId(), true);
 
             context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
         }
@@ -94,6 +94,6 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     protected void trackAppOpen(Context context, String pushId) {
-        Blueshift.getInstance(context).trackNotificationPageOpen(pushId);
+        Blueshift.getInstance(context).trackNotificationPageOpen(pushId, true);
     }
 }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -27,7 +27,7 @@ public class RichPushNotification {
         buildAndShowNotification(context, message);
 
         // Tracking the notification display.
-        Blueshift.getInstance(context).trackNotificationView(message.getId());
+        Blueshift.getInstance(context).trackNotificationView(message.getId(), true);
     }
 
     private static void buildAndShowNotification(Context context, Message message) {


### PR DESCRIPTION
## Bulk Events API implementation - Changes ##
- Created alarm manager and gave a default interval as `AlarmManager.INTERVAL_HALF_HOUR`
- The developer can change the interval by calling `setBatchInterval()` method of `Configuration`
- Updated methods by adding extra parameter that denotes if that event can be batched or not
- The events triggered inside SDK is set as bulk events. They are,
    - trackNotificationClick()
    - trackNotificationPageOpen()
    - trackNotificationView()
    - trackAppInstall()
    - trackAppOpen()
- The `sendEvent()` method is made Async to avoid disturbance to the UI thread with lot of work. As a result, few events api methods have their return type changed from boolean to void.
- The failed priority events events are queued and used first when next batch is created. instead of waiting for retry after 5 min.

~~**Note: Please don't merge this PR now. I am still working on possible performance improvements.**~~

## Updates - 31st Aug 2016 ##
- Optimized alarm manager to contain one alarm at a time. This is to avoid possible error of having multiple alarms during app updates.