### PR TITLE
Impelement Dialog Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Blueshift Android SDK - description goes here.
   * [Setup] (#setup)
     * [Permissions Required] (#permissions)
     * [Rich Push Notification] (#rich_push)
-    * [Track App Install] (#app_install_tracking)
     * [Initializing SDK] (#initialize_sdk)
     * [Setting user info] (#set_user_info)
   * [Track Events] (#track_events)
+  * [Track App Install] (#app_install_tracking)
+  * [Bulk Events] (#bulk_events)
   
 <a name="prerequisites"></a>
 # Prerequisites
@@ -122,23 +123,6 @@ If you wish to override the notifications received by the SDK, then add the foll
 </receiver>
 ```
 
-<a name="app_install_tracking"></a>
-##  App Install Tracking  ##
-
-Add the following block inside `<application>` tag to enable app install tracking by SDK.
-
-```xml
-<receiver
-    android:name="com.blueshift.receiver.AppInstallReceiver"
-    android:exported="true">
-    <intent-filter>
-        <action android:name="com.android.vending.INSTALL_REFERRER" />
-
-        <data android:scheme="package" />
-    </intent-filter>
-</receiver>
-```
-
 <a name="initialize_sdk"></a>
 ## Initializing SDK ##
 
@@ -153,7 +137,7 @@ configuration.setProductPage(ProductActivity.class);            // provide produ
 configuration.setCartPage(CartActivity.class);                  // provide cart activity class
 configuration.setOfferDisplayPage(OfferDisplayActivity.class);  // provide offers activity class
 
-// This time is used as batch interval. 30 min if not set.
+// This time is used as batch interval for bulk events api call. 30 min if not set.
 // It is recommended to use one of the following for API < 19 devices.
 // AlarmManager.INTERVAL_FIFTEEN_MINUTES
 // AlarmManager.INTERVAL_HALF_HOUR
@@ -191,3 +175,13 @@ Blueshift.getInstance(context).trackEvent("event_name", eventParams, canBatchThi
 ```
 
 Above example helps you in sending custom events. There are a bunch of APIs provided by the SDK to track predefined events like "pageload", "view" etc. You can find them under `Blueshift` class's instance.'
+
+<a name="app_install_tracking"></a>
+##  App Install Tracking  ##
+
+The SDK will track the app installs and will send the utm values as app_install event to the server.
+
+<a name="bulk_events"></a>
+##  Bulk Events  ##
+
+The SDK supports real-time events and batched events. The batched events are sent in an interval of 30min (if `setBatchInterval()` is not called by the developer during [sdk initialization] (#initialize_sdk)). The developer can specify each event whether to be sent with a batch or in real-time using the flad provided with each event method.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Add the following block inside `<application>` tag to enable deeplinking from no
         <action android:name="com.blueshift.sampleapp.ACTION_BUY" />
         <action android:name="com.blueshift.sampleapp.ACTION_OPEN_CART" />
         <action android:name="com.blueshift.sampleapp.ACTION_OPEN_OFFER_PAGE" />
+        <action android:name="com.blueshift.sampleapp.ACTION_OPEN_APP" />
 
         <category android:name="com.blueshift.sampleapp" />
     </intent-filter>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Blueshift Android SDK - description goes here.
   * [Setup] (#setup)
     * [Permissions Required] (#permissions)
     * [Rich Push Notification] (#rich_push)
-    * [Bulk Events Support] (#bulk_event)
     * [Track App Install] (#app_install_tracking)
     * [Initializing SDK] (#initialize_sdk)
     * [Setting user info] (#set_user_info)
@@ -121,15 +120,6 @@ If you wish to override the notifications received by the SDK, then add the foll
         <action android:name="com.blueshift.sampleapp.ACTION_PUSH_RECEIVED" />
     </intent-filter>
 </receiver>
-```
-
-<a name="bulk_event"></a>
-## Bulk Events Support ##
-
-Add this receiver inside `<application>` tag to enable batch events support. This is important! If this is missing in AndroidManifest.xml, the event tracking will not happen properly. All events marked for batching will not be sent.
-
-```xml
-<receiver android:name="com.blueshift.batch.AlarmReceiver"/>
 ```
 
 <a name="app_install_tracking"></a>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,20 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.blueshift">
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.blueshift">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
         android:supportsRtl="true">
+
+        <activity
+            android:name=".rich_push.NotificationActivity"
+            android:label=""
+            android:theme="@style/TransparentActivity" />
+
+        <!--Events batching-->
+        <receiver android:name="com.blueshift.batch.AlarmReceiver"/>
+        <!--End - Events batching-->
 
     </application>
 

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -16,6 +16,18 @@
         <receiver android:name="com.blueshift.batch.AlarmReceiver"/>
         <!--End - Events batching-->
 
+        <!--App install tracking-->
+        <receiver
+            android:name="com.blueshift.receiver.AppInstallReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.android.vending.INSTALL_REFERRER" />
+
+                <data android:scheme="package" />
+            </intent-filter>
+        </receiver>
+        <!--End - App install tracking-->
+
     </application>
 
 </manifest>

--- a/library/src/main/java/com/blueshift/model/Configuration.java
+++ b/library/src/main/java/com/blueshift/model/Configuration.java
@@ -12,6 +12,7 @@ public class Configuration {
     Class offerDisplayPage;
     String apiKey;
     long batchInterval;
+    int dialogTheme;
 
     public Configuration() {
         batchInterval = AlarmManager.INTERVAL_HALF_HOUR;
@@ -69,5 +70,19 @@ public class Configuration {
      */
     public void setBatchInterval(long batchInterval) {
         this.batchInterval = batchInterval;
+    }
+
+    public int getDialogTheme() {
+        return dialogTheme;
+    }
+
+    /**
+     * Theme used for creating dialog type notifications.
+     * Default value is `Theme.AppCompat.Dialog.Alert`
+     *
+     * @param dialogTheme user define theme's reference id
+     */
+    public void setDialogTheme(int dialogTheme) {
+        this.dialogTheme = dialogTheme;
     }
 }

--- a/library/src/main/java/com/blueshift/rich_push/Message.java
+++ b/library/src/main/java/com/blueshift/rich_push/Message.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
  */
 public class Message implements Serializable {
     public final static String CATEGORY_BUY = "buy";
-    public final static String CATEGORY_OFFER = "offer";
+    public final static String CATEGORY_OFFER = "promotion";
     public final static String CATEGORY_VIEW_CART = "view cart";
 
     String id;

--- a/library/src/main/java/com/blueshift/rich_push/Message.java
+++ b/library/src/main/java/com/blueshift/rich_push/Message.java
@@ -67,4 +67,8 @@ public class Message implements Serializable {
     public HashMap<String, Object> getData() {
         return data;
     }
+
+    public boolean isSilentPush() {
+        return getNotificationType() == NotificationType.Notification && getCategory() == NotificationCategory.SilentPush;
+    }
 }

--- a/library/src/main/java/com/blueshift/rich_push/Message.java
+++ b/library/src/main/java/com/blueshift/rich_push/Message.java
@@ -7,18 +7,15 @@ import java.util.HashMap;
  * Created by rahul on 18/2/15.
  */
 public class Message implements Serializable {
-    public final static String CATEGORY_BUY = "buy";
-    public final static String CATEGORY_OFFER = "promotion";
-    public final static String CATEGORY_VIEW_CART = "view cart";
-
     String id;
-    String type;
+    String notification_type;
     String title;
     String body;
     String category;
     String sku;
     String mrp;
     String price;
+    String url;
     String image_url;
     long expiry;
     HashMap<String, Object> data;
@@ -27,8 +24,8 @@ public class Message implements Serializable {
         return id;
     }
 
-    public String getType() {
-        return type;
+    public NotificationType getNotificationType() {
+        return NotificationType.fromString(notification_type);
     }
 
     public String getTitle() {
@@ -39,8 +36,8 @@ public class Message implements Serializable {
         return body;
     }
 
-    public String getCategory() {
-        return category;
+    public NotificationCategory getCategory() {
+        return NotificationCategory.fromString(category);
     }
 
     public String getSku() {
@@ -53,6 +50,10 @@ public class Message implements Serializable {
 
     public String getPrice() {
         return price;
+    }
+
+    public String getUrl() {
+        return url;
     }
 
     public String getImage_url() {

--- a/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -4,13 +4,21 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.Window;
 
 import com.blueshift.Blueshift;
+import com.blueshift.R;
+import com.blueshift.model.Configuration;
 
+/**
+ * Created by Rahul Raveendran
+ * <p>
+ * This activity is responsible for creating dialog notifications.
+ * Currently supports two types of dialogues.
+ */
 public class NotificationActivity extends AppCompatActivity {
 
     private Context mContext;
@@ -26,9 +34,29 @@ public class NotificationActivity extends AppCompatActivity {
         Message message = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
 
         if (message != null) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
-            builder.setMessage(message.getBody());
+            int theme = 0;
+
+            /**
+             * Check if there is a user defined theme, if yes assign it to `theme` variable.
+             */
+            Configuration configuration = Blueshift.getInstance(mContext).getConfiguration();
+            if (configuration != null) {
+                theme = configuration.getDialogTheme();
+            }
+
+            AlertDialog.Builder builder;
+
+            /**
+             * check if a valid `theme` is available, else use `BlueshiftDialogTheme`
+             */
+            if (theme == 0) {
+                builder = new AlertDialog.Builder(mContext, R.style.BlueshiftDialogTheme);
+            } else {
+                builder = new AlertDialog.Builder(mContext, theme);
+            }
+
             builder.setTitle(message.getTitle());
+            builder.setMessage(message.getBody());
 
             builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
                 @Override
@@ -52,16 +80,22 @@ public class NotificationActivity extends AppCompatActivity {
         }
     }
 
-
+    /**
+     * This method adds action buttons to the builder based on available category
+     *
+     * @param builder builder on which the atcions to be attached.
+     * @param message the message object that contains the category. this is also used as extra to launching activity
+     * @return updated builder object
+     */
     private AlertDialog.Builder setActions(AlertDialog.Builder builder, final Message message) {
         switch (message.getCategory()) {
             case AlertBoxOpenDismiss:
-                builder.setPositiveButton("Open", new DialogInterface.OnClickListener() {
+                builder.setPositiveButton(R.string.dialog_button_open, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
 
                         PackageManager packageManager = getPackageManager();
-                        Intent launcherIntent  = packageManager.getLaunchIntentForPackage(getPackageName());
+                        Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
                         launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
                         launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(launcherIntent);
@@ -72,12 +106,12 @@ public class NotificationActivity extends AppCompatActivity {
                     }
                 });
 
-                builder.setNegativeButton("Dismiss", null);
+                builder.setNegativeButton(R.string.dialog_button_dismiss, null);
 
                 break;
 
             case AlertBoxDismiss:
-                builder.setNegativeButton("Dismiss", null);
+                builder.setNegativeButton(R.string.dialog_button_dismiss, null);
 
                 break;
         }

--- a/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -1,0 +1,87 @@
+package com.blueshift.rich_push;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.Window;
+
+import com.blueshift.Blueshift;
+
+public class NotificationActivity extends AppCompatActivity {
+
+    private Context mContext;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        mContext = this;
+
+        Message message = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+
+        if (message != null) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
+            builder.setMessage(message.getBody());
+            builder.setTitle(message.getTitle());
+
+            builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
+                @Override
+                public void onCancel(DialogInterface dialog) {
+                    finish();
+                }
+            });
+
+            builder.setOnDismissListener(new DialogInterface.OnDismissListener() {
+                @Override
+                public void onDismiss(DialogInterface dialog) {
+                    finish();
+                }
+            });
+
+            builder = setActions(builder, message);
+
+            builder.create().show();
+        } else {
+            finish();
+        }
+    }
+
+
+    private AlertDialog.Builder setActions(AlertDialog.Builder builder, final Message message) {
+        switch (message.getCategory()) {
+            case AlertBoxOpenDismiss:
+                builder.setPositiveButton("Open", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+
+                        PackageManager packageManager = getPackageManager();
+                        Intent launcherIntent  = packageManager.getLaunchIntentForPackage(getPackageName());
+                        launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        startActivity(launcherIntent);
+
+                        Blueshift.getInstance(mContext).trackNotificationPageOpen(message.id, true);
+
+                        finish();
+                    }
+                });
+
+                builder.setNegativeButton("Dismiss", null);
+
+                break;
+
+            case AlertBoxDismiss:
+                builder.setNegativeButton("Dismiss", null);
+
+                break;
+        }
+
+        return builder;
+    }
+}

--- a/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
@@ -1,0 +1,61 @@
+package com.blueshift.rich_push;
+
+/**
+ * Created by rahul on 6/9/16.
+ */
+public enum NotificationCategory {
+    Buy,
+    ViewCart,
+    Promotion,
+    AlertBoxOpenDismiss,
+    AlertBoxDismiss,
+    Unknown;
+
+    public static NotificationCategory fromString(String notificationCategory) {
+        if (notificationCategory != null) {
+            switch (notificationCategory) {
+                case "buy":
+                    return Buy;
+
+                case "view cart":
+                    return ViewCart;
+
+                case "promotion":
+                    return Promotion;
+
+                case "alert_box":
+                    return AlertBoxOpenDismiss;
+
+                case "alert_box_1_button":
+                    return AlertBoxDismiss;
+
+                default:
+                    return Unknown;
+            }
+        } else {
+            return Unknown;
+        }
+    }
+
+    public int getNotificationId() {
+        switch (this) {
+            case Buy:
+                return 100;
+
+            case ViewCart:
+                return 200;
+
+            case Promotion:
+                return 300;
+
+            case AlertBoxOpenDismiss:
+                return 400;
+
+            case AlertBoxDismiss:
+                return 500;
+
+            default:
+                return 0;
+        }
+    }
+}

--- a/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
@@ -9,6 +9,7 @@ public enum NotificationCategory {
     Promotion,
     AlertBoxOpenDismiss,
     AlertBoxDismiss,
+    SilentPush,
     Unknown;
 
     public static NotificationCategory fromString(String notificationCategory) {
@@ -28,6 +29,9 @@ public enum NotificationCategory {
 
                 case "alert_box_1_button":
                     return AlertBoxDismiss;
+
+                case "silent_push":
+                    return SilentPush;
 
                 default:
                     return Unknown;

--- a/library/src/main/java/com/blueshift/rich_push/NotificationType.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationType.java
@@ -1,0 +1,27 @@
+package com.blueshift.rich_push;
+
+/**
+ * Created by rahul on 6/9/16.
+ */
+public enum NotificationType {
+    AlertDialog,
+    Notification,
+    Unknown;
+
+    public static NotificationType fromString(String notificationType) {
+        if (notificationType != null) {
+            switch (notificationType) {
+                case "alert":
+                    return AlertDialog;
+
+                case "notification":
+                    return Notification;
+
+                default:
+                    return Unknown;
+            }
+        } else {
+            return Unknown;
+        }
+    }
+}

--- a/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -90,8 +90,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
         Configuration configuration = Blueshift.getInstance(context).getConfiguration();
         if (configuration != null && configuration.getOfferDisplayPage() != null) {
             Intent pageLauncherIntent = new Intent(context, configuration.getOfferDisplayPage());
-            pageLauncherIntent.putExtra("image_url", message.getImage_url());
-            pageLauncherIntent.putExtra("data", message.getData());
+            pageLauncherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
 

--- a/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -4,6 +4,8 @@ import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.util.Log;
 
 import com.blueshift.Blueshift;
 import com.blueshift.model.Configuration;
@@ -15,6 +17,8 @@ public class RichPushActionReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        Log.d("RichPushActionReceiver", "onReceive - " + intent.getAction());
+
         String action = intent.getAction();
         Message message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
         if (action != null && message != null) {
@@ -26,6 +30,8 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                 displayCartPage(context, message);
             } else if (action.equals(RichPushConstants.ACTION_OPEN_OFFER_PAGE(context))) {
                 displayOfferDisplayPage(context, message);
+            } else if (action.equals(RichPushConstants.ACTION_OPEN_APP(context))) {
+                openApp(context, message);
             }
 
             NotificationManager notificationManager =
@@ -88,6 +94,18 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             pageLauncherIntent.putExtra("data", message.getData());
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
+
+            trackAppOpen(context, message.getId());
+        }
+    }
+
+    protected void openApp(Context context, Message message) {
+        if (context != null) {
+            PackageManager packageManager = context.getPackageManager();
+            Intent launcherIntent  = packageManager.getLaunchIntentForPackage(context.getPackageName());
+            launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+            launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(launcherIntent);
 
             trackAppOpen(context, message.getId());
         }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -21,18 +21,8 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
         String messageJSON = intent.getStringExtra(RichPushConstants.EXTRA_MESSAGE);
         if (messageJSON != null) {
             try {
-                final Message message = new Gson().fromJson(messageJSON, Message.class);
-                /**
-                 * The rich push rendering require network access (ex: image download)
-                 * Since network operations are not allowed in main thread, we
-                 * are rendering the push message in a different thread.
-                 */
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        RichPushNotification.handleMessage(context, message);
-                    }
-                }).start();
+                Message message = new Gson().fromJson(messageJSON, Message.class);
+                RichPushNotification.handleMessage(context, message);
             } catch (JsonSyntaxException e) {
                 Log.e(LOG_TAG, "Invalid JSON in push message: " + e.getMessage());
             }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -22,7 +22,16 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
         if (messageJSON != null) {
             try {
                 Message message = new Gson().fromJson(messageJSON, Message.class);
-                RichPushNotification.handleMessage(context, message);
+                if (message.isSilentPush()) {
+                    /**
+                     * This is a silent push to track uninstalls.
+                     * SDK has nothing to do with this. If this push was not delivered,
+                     * server will track GCM registrations fails and will decide if the app is uninstalled or not.
+                     */
+                    Log.i(LOG_TAG, "A silent push received.");
+                } else {
+                    RichPushNotification.handleMessage(context, message);
+                }
             } catch (JsonSyntaxException e) {
                 Log.e(LOG_TAG, "Invalid JSON in push message: " + e.getMessage());
             }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushConstants.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushConstants.java
@@ -16,6 +16,7 @@ public final class RichPushConstants {
     public static String ACTION_BUY(Context context) { return context.getPackageName() + ".ACTION_BUY"; }
     public static String ACTION_OPEN_CART(Context context) { return context.getPackageName() + ".ACTION_OPEN_CART"; }
     public static String ACTION_OPEN_OFFER_PAGE(Context context) { return context.getPackageName() + ".ACTION_OPEN_OFFER_PAGE"; }
+    public static String ACTION_OPEN_APP(Context context) { return context.getPackageName() + ".ACTION_OPEN_APP"; }
 
     /**
      * Action sent to host app for handling the push message at the user end.

--- a/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -24,7 +24,14 @@ public class RichPushNotification {
     private final static String LOG_TAG = RichPushNotification.class.getSimpleName();
 
     public static void handleMessage(Context context, Message message) {
-        buildAndShowNotification(context, message);
+        switch (message.getNotificationType()) {
+            case AlertDialog:
+                break;
+
+            case Notification:
+                buildAndShowNotification(context, message);
+                break;
+        }
 
         // Tracking the notification display.
         Blueshift.getInstance(context).trackNotificationView(message.getId(), true);
@@ -41,49 +48,70 @@ public class RichPushNotification {
         if (configuration != null) {
             builder.setSmallIcon(configuration.getAppIcon());
 
-            if (message.category.equals(Message.CATEGORY_BUY)) {
-                notificationID = 100;
-                if (configuration.getProductPage() != null) {
-                    Intent intent = new Intent(RichPushConstants.ACTION_VIEW(context));
-                    intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
-                    intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
-                    PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
-                            0, intent, PendingIntent.FLAG_ONE_SHOT);
+            switch (message.getCategory()) {
+                case Buy:
+                    notificationID = NotificationCategory.Buy.getNotificationId();
+                    if (configuration.getProductPage() != null) {
+                        Intent intent = new Intent(RichPushConstants.ACTION_VIEW(context));
+                        intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
+                        PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
+                                0, intent, PendingIntent.FLAG_ONE_SHOT);
 
-                    builder.addAction(0, "View", pendingIntent);
-                }
+                        builder.addAction(0, "View", pendingIntent);
+                    }
 
-                if (configuration.getCartPage() != null) {
-                    Intent intent = new Intent(RichPushConstants.ACTION_BUY(context));
-                    intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
-                    intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
-                    PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
-                            0, intent, PendingIntent.FLAG_ONE_SHOT);
+                    if (configuration.getCartPage() != null) {
+                        Intent intent = new Intent(RichPushConstants.ACTION_BUY(context));
+                        intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
+                        PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
+                                0, intent, PendingIntent.FLAG_ONE_SHOT);
 
-                    builder.addAction(0, "Buy", pendingIntent);
-                }
-            } else if (message.category.equals(Message.CATEGORY_VIEW_CART)) {
-                notificationID = 200;
-                if (configuration.getCartPage() != null) {
-                    Intent intent = new Intent(RichPushConstants.ACTION_OPEN_CART(context));
-                    intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
-                    intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
-                    PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
-                            0, intent, PendingIntent.FLAG_ONE_SHOT);
+                        builder.addAction(0, "Buy", pendingIntent);
+                    }
 
-                    builder.addAction(0, "Open Cart", pendingIntent);
-                }
-            } else if (message.category.equals(Message.CATEGORY_OFFER)) {
-                notificationID = 300;
-                if (configuration.getOfferDisplayPage() != null) {
-                    Intent intent = new Intent(RichPushConstants.ACTION_OPEN_OFFER_PAGE(context));
+                    break;
+
+                case ViewCart:
+                    notificationID = NotificationCategory.ViewCart.getNotificationId();
+                    if (configuration.getCartPage() != null) {
+                        Intent intent = new Intent(RichPushConstants.ACTION_OPEN_CART(context));
+                        intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
+                        PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
+                                0, intent, PendingIntent.FLAG_ONE_SHOT);
+
+                        builder.addAction(0, "Open Cart", pendingIntent);
+                    }
+
+                    break;
+
+                case Promotion:
+                    notificationID = NotificationCategory.Promotion.getNotificationId();
+                    if (configuration.getOfferDisplayPage() != null) {
+                        Intent intent = new Intent(RichPushConstants.ACTION_OPEN_OFFER_PAGE(context));
+                        intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
+                        PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
+                                0, intent, PendingIntent.FLAG_ONE_SHOT);
+
+                        builder.setContentIntent(pendingIntent);
+                    }
+
+                    break;
+
+                default:
+                    /**
+                     * Default action is to open app and send all details as extra inside intent
+                     */
+                    Intent intent = new Intent(RichPushConstants.ACTION_OPEN_APP(context));
                     intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
                     intent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationID);
                     PendingIntent pendingIntent = PendingIntent.getBroadcast(context,
                             0, intent, PendingIntent.FLAG_ONE_SHOT);
 
                     builder.setContentIntent(pendingIntent);
-                }
             }
         }
 

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="blueshift_theme_blue">#0081b7</color>
+</resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Blueshift Android SDK</string>
+    <string name="dialog_button_open">Open</string>
+    <string name="dialog_button_dismiss">Dismiss</string>
 </resources>

--- a/library/src/main/res/values/style.xml
+++ b/library/src/main/res/values/style.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="TransparentActivity" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -10,4 +10,6 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
+    <style name="BlueshiftDialogTheme" parent="Theme.AppCompat.Dialog.Alert"/>
+
 </resources>


### PR DESCRIPTION
## Dialog Notifications ##
- Separated notifications into two. `AlertDialog` and `Notification`
- Defined `enum` for both notification type and category
- Moved alarm receiver registration into library's `AndroidManifest.xml`
- Updated README file accordingly

## Updates on 07-sep ##
- Enabled silent push support inside SDK
- Passing complete message object as extra to promotion activity
- Moved install referrer receiver into SDK. (updated README)
- Provision to add user defined theme for dialog notifications like this.
```java
configuration.setDialogTheme(R.style.dialog_theme);
```