### PR TITLE
Enhancements & Bug Fixes

### DIFF
--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -752,6 +752,21 @@ public class Blueshift {
         trackEvent(BlueshiftConstants.EVENT_APP_OPEN, eventParams, canBatchThisEvent);
     }
 
+    public void trackAlertDismiss(String notificationId, boolean canBatchThisEvent) {
+        trackAlertDismiss(notificationId, null, canBatchThisEvent);
+    }
+
+    public void trackAlertDismiss(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
+        HashMap<String, Object> eventParams = new HashMap<>();
+        eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
+
+        if (params != null) {
+            eventParams.putAll(params);
+        }
+
+        trackEvent(BlueshiftConstants.EVENT_DISMISS_ALERT, eventParams, canBatchThisEvent);
+    }
+
     /**
      * Updates the mDeviceParams with advertising ID
      */

--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -232,6 +232,14 @@ public class Blueshift {
                         // Appending params with the device dependant details.
                         requestParams.putAll(params);
 
+                        // check if device id (Android Ad Id) is available in parameters' list.
+                        // if not found, try to get it now and fill it in.
+                        Object deviceId = requestParams.get(BlueshiftConstants.KEY_DEVICE_IDENTIFIER);
+                        if (deviceId == null) {
+                            String adId = DeviceUtils.getAdvertisingID(mContext);
+                            requestParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, adId);
+                        }
+
                         // Appending email and customer id.
                         UserInfo userInfo = UserInfo.getInstance(mContext);
                         if (userInfo != null) {

--- a/library/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/library/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -34,6 +34,7 @@ public class BlueshiftConstants {
     public static final String EVENT_APP_INSTALL = "app_install";
     public static final String EVENT_PUSH_VIEW  = "push_view";
     public static final String EVENT_PUSH_CLICK  = "push_click";
+    public static final String EVENT_DISMISS_ALERT = "dismiss_alert";
 
     /**
      * Names of parameters (key) we send to Blueshift server along with events

--- a/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -75,6 +75,9 @@ public class NotificationActivity extends AppCompatActivity {
             builder = setActions(builder, message);
 
             builder.create().show();
+
+            // Tracking the notification display.
+            Blueshift.getInstance(mContext).trackNotificationView(message.getId(), true);
         } else {
             finish();
         }
@@ -94,13 +97,15 @@ public class NotificationActivity extends AppCompatActivity {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
 
+                        Blueshift.getInstance(mContext).trackNotificationClick(message.getId(), true);
+
                         PackageManager packageManager = getPackageManager();
                         Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
                         launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
                         launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(launcherIntent);
 
-                        Blueshift.getInstance(mContext).trackNotificationPageOpen(message.id, true);
+                        Blueshift.getInstance(mContext).trackNotificationPageOpen(message.getId(), true);
 
                         finish();
                     }

--- a/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -22,6 +22,7 @@ import com.blueshift.model.Configuration;
 public class NotificationActivity extends AppCompatActivity {
 
     private Context mContext;
+    private Message mMessage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,9 +32,9 @@ public class NotificationActivity extends AppCompatActivity {
 
         mContext = this;
 
-        Message message = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+        mMessage = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
 
-        if (message != null) {
+        if (mMessage != null) {
             int theme = 0;
 
             /**
@@ -55,8 +56,8 @@ public class NotificationActivity extends AppCompatActivity {
                 builder = new AlertDialog.Builder(mContext, theme);
             }
 
-            builder.setTitle(message.getTitle());
-            builder.setMessage(message.getBody());
+            builder.setTitle(mMessage.getTitle());
+            builder.setMessage(mMessage.getBody());
 
             builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
                 @Override
@@ -72,12 +73,12 @@ public class NotificationActivity extends AppCompatActivity {
                 }
             });
 
-            builder = setActions(builder, message);
+            builder = setActions(builder);
 
             builder.create().show();
 
             // Tracking the notification display.
-            Blueshift.getInstance(mContext).trackNotificationView(message.getId(), true);
+            Blueshift.getInstance(mContext).trackNotificationView(mMessage.getId(), true);
         } else {
             finish();
         }
@@ -87,40 +88,48 @@ public class NotificationActivity extends AppCompatActivity {
      * This method adds action buttons to the builder based on available category
      *
      * @param builder builder on which the atcions to be attached.
-     * @param message the message object that contains the category. this is also used as extra to launching activity
      * @return updated builder object
      */
-    private AlertDialog.Builder setActions(AlertDialog.Builder builder, final Message message) {
-        switch (message.getCategory()) {
+    private AlertDialog.Builder setActions(AlertDialog.Builder builder) {
+        switch (mMessage.getCategory()) {
             case AlertBoxOpenDismiss:
                 builder.setPositiveButton(R.string.dialog_button_open, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
 
-                        Blueshift.getInstance(mContext).trackNotificationClick(message.getId(), true);
+                        Blueshift.getInstance(mContext).trackNotificationClick(mMessage.getId(), true);
 
                         PackageManager packageManager = getPackageManager();
                         Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
-                        launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                        launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, mMessage);
                         launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(launcherIntent);
 
-                        Blueshift.getInstance(mContext).trackNotificationPageOpen(message.getId(), true);
+                        Blueshift.getInstance(mContext).trackNotificationPageOpen(mMessage.getId(), true);
 
-                        finish();
+                        dialog.dismiss();
                     }
                 });
 
-                builder.setNegativeButton(R.string.dialog_button_dismiss, null);
+                builder.setNegativeButton(R.string.dialog_button_dismiss, mOnDismissClickListener);
 
                 break;
 
             case AlertBoxDismiss:
-                builder.setNegativeButton(R.string.dialog_button_dismiss, null);
+                builder.setNegativeButton(R.string.dialog_button_dismiss, mOnDismissClickListener);
 
                 break;
         }
 
         return builder;
     }
+
+    private DialogInterface.OnClickListener mOnDismissClickListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            Blueshift.getInstance(mContext).trackAlertDismiss(mMessage.getId(), true);
+
+            dialog.dismiss();
+        }
+    };
 }

--- a/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
@@ -1,5 +1,7 @@
 package com.blueshift.rich_push;
 
+import android.util.Log;
+
 /**
  * Created by rahul on 6/9/16.
  */
@@ -34,6 +36,8 @@ public enum NotificationCategory {
                     return SilentPush;
 
                 default:
+                    Log.w("NotificationCategory", "Unknown notification_type found: " + notificationCategory);
+
                     return Unknown;
             }
         } else {

--- a/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationCategory.java
@@ -14,6 +14,8 @@ public enum NotificationCategory {
     SilentPush,
     Unknown;
 
+    private static final String LOG_TAG = "NotificationCategory";
+
     public static NotificationCategory fromString(String notificationCategory) {
         if (notificationCategory != null) {
             switch (notificationCategory) {
@@ -36,11 +38,13 @@ public enum NotificationCategory {
                     return SilentPush;
 
                 default:
-                    Log.w("NotificationCategory", "Unknown notification_type found: " + notificationCategory);
+                    Log.w(LOG_TAG, "Unknown 'category' found: " + notificationCategory);
 
                     return Unknown;
             }
         } else {
+            Log.w(LOG_TAG, "'category' is not available inside 'message'.");
+
             return Unknown;
         }
     }

--- a/library/src/main/java/com/blueshift/rich_push/NotificationType.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationType.java
@@ -1,5 +1,7 @@
 package com.blueshift.rich_push;
 
+import android.util.Log;
+
 /**
  * Created by rahul on 6/9/16.
  */
@@ -18,6 +20,8 @@ public enum NotificationType {
                     return Notification;
 
                 default:
+                    Log.w("NotificationType", "Unknown notification_type found: " + notificationType);
+
                     return Unknown;
             }
         } else {

--- a/library/src/main/java/com/blueshift/rich_push/NotificationType.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationType.java
@@ -10,6 +10,8 @@ public enum NotificationType {
     Notification,
     Unknown;
 
+    private static final String LOG_TAG = "NotificationType";
+
     public static NotificationType fromString(String notificationType) {
         if (notificationType != null) {
             switch (notificationType) {
@@ -20,11 +22,13 @@ public enum NotificationType {
                     return Notification;
 
                 default:
-                    Log.w("NotificationType", "Unknown notification_type found: " + notificationType);
+                    Log.w(LOG_TAG, "Unknown 'notification_type' found: " + notificationType);
 
                     return Unknown;
             }
         } else {
+            Log.w(LOG_TAG, "'notification_type' is not available inside 'message'.");
+
             return Unknown;
         }
     }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
 import android.os.Environment;
 import android.support.v7.app.NotificationCompat;
 import android.util.Log;
@@ -35,18 +36,17 @@ public class RichPushNotification {
                  * Since network operations are not allowed in main thread, we
                  * are rendering the push message in a different thread.
                  */
-                new Thread(new Runnable() {
+                new AsyncTask<Void, Void, Boolean>() {
                     @Override
-                    public void run() {
+                    protected Boolean doInBackground(Void... params) {
                         buildAndShowNotification(context, message);
+
+                        return null;
                     }
-                }).run();
+                }.execute();
 
                 break;
         }
-
-        // Tracking the notification display.
-        Blueshift.getInstance(context).trackNotificationView(message.getId(), true);
     }
 
     private static void buildAndShowAlertDialog(Context context, Message message) {
@@ -140,6 +140,8 @@ public class RichPushNotification {
 
         if (message.getImage_url() != null && !message.getImage_url().isEmpty()) {
             String destinationPath = Environment.getExternalStorageDirectory().getAbsolutePath() + "/temp.jpg";
+            Log.i(LOG_TAG, "Image getting downloaded to: " + destinationPath);
+
             if (NetworkUtils.downloadFile(message.getImage_url(), destinationPath)) {
                 Bitmap bitmap = BitmapFactory.decodeFile(destinationPath);
                 builder.setStyle(new NotificationCompat.BigPictureStyle().bigPicture(bitmap));
@@ -151,5 +153,8 @@ public class RichPushNotification {
         NotificationManager notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.notify(notificationID, builder.build());
+
+        // Tracking the notification display.
+        Blueshift.getInstance(context).trackNotificationView(message.getId(), true);
     }
 }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -8,15 +8,15 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
-import android.os.Environment;
 import android.support.v7.app.NotificationCompat;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.blueshift.Blueshift;
 import com.blueshift.model.Configuration;
-import com.blueshift.util.NetworkUtils;
 
-import java.io.File;
+import java.io.IOException;
+import java.net.URL;
 
 /**
  * Created by rahul on 18/2/15.
@@ -138,15 +138,15 @@ public class RichPushNotification {
         builder.setContentTitle(message.getTitle());
         builder.setContentText(message.getBody());
 
-        if (message.getImage_url() != null && !message.getImage_url().isEmpty()) {
-            String destinationPath = Environment.getExternalStorageDirectory().getAbsolutePath() + "/temp.jpg";
-            Log.i(LOG_TAG, "Image getting downloaded to: " + destinationPath);
-
-            if (NetworkUtils.downloadFile(message.getImage_url(), destinationPath)) {
-                Bitmap bitmap = BitmapFactory.decodeFile(destinationPath);
-                builder.setStyle(new NotificationCompat.BigPictureStyle().bigPicture(bitmap));
-                File file = new File(destinationPath);
-                Log.d(LOG_TAG, "Deleting cached image " + (file.delete() ? "success." : "failed."));
+        if (!TextUtils.isEmpty(message.getImage_url())) {
+            try {
+                URL imageURL = new URL(message.getImage_url());
+                Bitmap bitmap = BitmapFactory.decodeStream(imageURL.openStream());
+                if (bitmap != null) {
+                    builder.setStyle(new NotificationCompat.BigPictureStyle().bigPicture(bitmap));
+                }
+            } catch (IOException e) {
+                Log.e(LOG_TAG, "Could not load image. " + e.getMessage());
             }
         }
 


### PR DESCRIPTION
## Changes ##
- Ensured the `Android Ad ID` is being added in parameters' list when the first `app_open` and `pageload` events are added in batch queue.
- Fixed an issue with image download for Notification
- Replaced image download with bitmap decoding from stream using URL.
- Fixed issue with `push_view` being called when the notification is sent with invalid type.
- Added proper event calls when dialog notifications are used.
- Added proper log for invalid `notification_type` / `category` cases.
- Added new event `dismiss_alert`. Triggered when user clicks on `dismiss` in dialog type notifications.