### PR TITLE
Campaign parameter tracking enabled

### DIFF
--- a/library/src/main/java/com/blueshift/Blueshift.java
+++ b/library/src/main/java/com/blueshift/Blueshift.java
@@ -27,6 +27,7 @@ import com.blueshift.model.Configuration;
 import com.blueshift.model.Product;
 import com.blueshift.model.Subscription;
 import com.blueshift.model.UserInfo;
+import com.blueshift.rich_push.Message;
 import com.blueshift.type.SubscriptionState;
 import com.blueshift.util.DeviceUtils;
 import com.google.gson.Gson;
@@ -707,6 +708,14 @@ public class Blueshift {
         }
     }
 
+    public void trackNotificationView(Message message, boolean canBatchThisEvent) {
+        if (message != null) {
+            trackNotificationView(message.getId(), message.getCampaignAttr(), canBatchThisEvent);
+        } else {
+            Log.e(LOG_TAG, "No message available");
+        }
+    }
+
     public void trackNotificationView(String notificationId, boolean canBatchThisEvent) {
         trackNotificationView(notificationId, null, canBatchThisEvent);
     }
@@ -720,6 +729,14 @@ public class Blueshift {
         }
 
         trackEvent(BlueshiftConstants.EVENT_PUSH_VIEW, eventParams, canBatchThisEvent);
+    }
+
+    public void trackNotificationClick(Message message, boolean canBatchThisEvent) {
+        if (message != null) {
+            trackNotificationClick(message.getId(), message.getCampaignAttr(), canBatchThisEvent);
+        } else {
+            Log.e(LOG_TAG, "No message available");
+        }
     }
 
     public void trackNotificationClick(String notificationId, boolean canBatchThisEvent) {
@@ -737,6 +754,14 @@ public class Blueshift {
         trackEvent(BlueshiftConstants.EVENT_PUSH_CLICK, eventParams, canBatchThisEvent);
     }
 
+    public void trackNotificationPageOpen(Message message, boolean canBatchThisEvent) {
+        if (message != null) {
+            trackNotificationPageOpen(message.getId(), message.getCampaignAttr(), canBatchThisEvent);
+        } else {
+            Log.e(LOG_TAG, "No message available");
+        }
+    }
+
     public void trackNotificationPageOpen(String notificationId, boolean canBatchThisEvent) {
         trackNotificationPageOpen(notificationId, null, canBatchThisEvent);
     }
@@ -750,6 +775,14 @@ public class Blueshift {
         }
 
         trackEvent(BlueshiftConstants.EVENT_APP_OPEN, eventParams, canBatchThisEvent);
+    }
+
+    public void trackAlertDismiss(Message message, boolean canBatchThisEvent) {
+        if (message != null) {
+            trackAlertDismiss(message.getId(), message.getCampaignAttr(), canBatchThisEvent);
+        } else {
+            Log.e(LOG_TAG, "No message available");
+        }
     }
 
     public void trackAlertDismiss(String notificationId, boolean canBatchThisEvent) {

--- a/library/src/main/java/com/blueshift/rich_push/Message.java
+++ b/library/src/main/java/com/blueshift/rich_push/Message.java
@@ -49,7 +49,7 @@ public class Message implements Serializable {
     }
 
     public boolean isCampaignPush() {
-        return !TextUtils.isEmpty(bsft_experiment_uuid) || !TextUtils.isEmpty(bsft_user_uuid);
+        return !TextUtils.isEmpty(bsft_experiment_uuid) && !TextUtils.isEmpty(bsft_user_uuid);
     }
 
     public HashMap<String, Object> getCampaignAttr() {

--- a/library/src/main/java/com/blueshift/rich_push/Message.java
+++ b/library/src/main/java/com/blueshift/rich_push/Message.java
@@ -1,5 +1,7 @@
 package com.blueshift.rich_push;
 
+import android.text.TextUtils;
+
 import java.io.Serializable;
 import java.util.HashMap;
 
@@ -7,18 +9,60 @@ import java.util.HashMap;
  * Created by rahul on 18/2/15.
  */
 public class Message implements Serializable {
-    String id;
-    String notification_type;
-    String title;
-    String body;
-    String category;
-    String sku;
-    String mrp;
-    String price;
-    String url;
-    String image_url;
-    long expiry;
-    HashMap<String, Object> data;
+    public static final String EXTRA_MESSAGE = "message";
+    public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
+    public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
+
+    // these parameters comes outside 'message' in push message.
+    // we're adding them inside for avoiding major code changes in sdk.
+    private String bsft_experiment_uuid;
+    private String bsft_user_uuid;
+
+    // Message payload values
+    private String id;
+    private String notification_type;
+    private String title;
+    private String body;
+    private String category;
+    private String sku;
+    private String mrp;
+    private String price;
+    private String url;
+    private String image_url;
+    private long expiry;
+    private HashMap<String, Object> data;
+
+    public String getBsftExperimentUuid() {
+        return bsft_experiment_uuid;
+    }
+
+    public void setBsftExperimentUuid(String bsftExperimentUuid) {
+        this.bsft_experiment_uuid = bsftExperimentUuid;
+    }
+
+    public String getBsftUserUuid() {
+        return bsft_user_uuid;
+    }
+
+    public void setBsftUserUuid(String bsftUserUuid) {
+        this.bsft_user_uuid = bsftUserUuid;
+    }
+
+    public boolean isCampaignPush() {
+        return !TextUtils.isEmpty(bsft_experiment_uuid) || !TextUtils.isEmpty(bsft_user_uuid);
+    }
+
+    public HashMap<String, Object> getCampaignAttr() {
+        HashMap<String, Object> attributes = null;
+
+        if (isCampaignPush()) {
+            attributes = new HashMap<>();
+            attributes.put(EXTRA_BSFT_EXPERIMENT_UUID, getBsftExperimentUuid());
+            attributes.put(EXTRA_BSFT_USER_UUID, getBsftUserUuid());
+        }
+
+        return attributes;
+    }
 
     public String getId() {
         return id;

--- a/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/library/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -78,7 +78,7 @@ public class NotificationActivity extends AppCompatActivity {
             builder.create().show();
 
             // Tracking the notification display.
-            Blueshift.getInstance(mContext).trackNotificationView(mMessage.getId(), true);
+            Blueshift.getInstance(mContext).trackNotificationView(mMessage, true);
         } else {
             finish();
         }
@@ -97,7 +97,7 @@ public class NotificationActivity extends AppCompatActivity {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
 
-                        Blueshift.getInstance(mContext).trackNotificationClick(mMessage.getId(), true);
+                        Blueshift.getInstance(mContext).trackNotificationClick(mMessage, true);
 
                         PackageManager packageManager = getPackageManager();
                         Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
@@ -105,7 +105,7 @@ public class NotificationActivity extends AppCompatActivity {
                         launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(launcherIntent);
 
-                        Blueshift.getInstance(mContext).trackNotificationPageOpen(mMessage.getId(), true);
+                        Blueshift.getInstance(mContext).trackNotificationPageOpen(mMessage, true);
 
                         dialog.dismiss();
                     }
@@ -127,7 +127,7 @@ public class NotificationActivity extends AppCompatActivity {
     private DialogInterface.OnClickListener mOnDismissClickListener = new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {
-            Blueshift.getInstance(mContext).trackAlertDismiss(mMessage.getId(), true);
+            Blueshift.getInstance(mContext).trackAlertDismiss(mMessage, true);
 
             dialog.dismiss();
         }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -38,7 +38,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                     (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.cancel(intent.getIntExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, 0));
 
-            Blueshift.getInstance(context).trackNotificationClick(message.getId(), true);
+            Blueshift.getInstance(context).trackNotificationClick(message, true);
 
             context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
         }
@@ -55,7 +55,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
 
-            trackAppOpen(context, message.getId());
+            trackAppOpen(context, message);
         }
     }
 
@@ -70,7 +70,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
 
-            trackAppOpen(context, message.getId());
+            trackAppOpen(context, message);
         }
     }
 
@@ -82,7 +82,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
 
-            trackAppOpen(context, message.getId());
+            trackAppOpen(context, message);
         }
     }
 
@@ -94,7 +94,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             pageLauncherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(pageLauncherIntent);
 
-            trackAppOpen(context, message.getId());
+            trackAppOpen(context, message);
         }
     }
 
@@ -106,11 +106,11 @@ public class RichPushActionReceiver extends BroadcastReceiver {
             launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(launcherIntent);
 
-            trackAppOpen(context, message.getId());
+            trackAppOpen(context, message);
         }
     }
 
-    protected void trackAppOpen(Context context, String pushId) {
-        Blueshift.getInstance(context).trackNotificationPageOpen(pushId, true);
+    protected void trackAppOpen(Context context, Message message) {
+        Blueshift.getInstance(context).trackNotificationPageOpen(message, true);
     }
 }

--- a/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/library/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -155,6 +155,6 @@ public class RichPushNotification {
         notificationManager.notify(notificationID, builder.build());
 
         // Tracking the notification display.
-        Blueshift.getInstance(context).trackNotificationView(message.getId(), true);
+        Blueshift.getInstance(context).trackNotificationView(message, true);
     }
 }


### PR DESCRIPTION
## Changes ##
1. Added one more notification tracking method for each event that accepts object of `Message`
2. Tracking if `bsft_experiment_uuid` or `bsft_user_uuid` is coming with the push message parallel to `message`. If found they're sent back with notification tracking events such as `push_view`, `push_click` etc