### PR TITLE
Added separate actions on carousel image clicks

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/rich_push/CarouselElement.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CarouselElement.java
@@ -1,6 +1,7 @@
 package com.blueshift.rich_push;
 
 import java.io.Serializable;
+import java.util.HashMap;
 
 /**
  * @author Rahul Raveendran V P
@@ -10,6 +11,7 @@ import java.io.Serializable;
 public class CarouselElement implements Serializable {
     private String image_url;
     private String action;
+    private HashMap data;
 
     public String getImageUrl() {
         return image_url;
@@ -17,5 +19,9 @@ public class CarouselElement implements Serializable {
 
     public String getAction() {
         return action;
+    }
+
+    public HashMap getData() {
+        return data;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -159,10 +159,9 @@ public class CustomNotificationFactory {
                         }
                     }
 
-                    String action = RichPushConstants.ACTION_OPEN_APP(context);
                     contentView.setOnClickPendingIntent(
                             R.id.big_picture,
-                            getNotificationClickPendingIntent(action, context, message)
+                            getCarouselImageClickPendingIntent(context, message, element)
                     );
 
                     contentView.setOnClickPendingIntent(
@@ -289,10 +288,9 @@ public class CustomNotificationFactory {
 
                         contentView.setImageViewBitmap(resId, bitmap);
 
-                        String action = RichPushConstants.buildAction(context, element.getAction());
                         contentView.setOnClickPendingIntent(
                                 resId,
-                                getNotificationClickPendingIntent(action, context, message)
+                                getCarouselImageClickPendingIntent(context, message, element)
                         );
                     }
                 } catch (IOException e) {
@@ -345,6 +343,26 @@ public class CustomNotificationFactory {
         intent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
 
         return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    /**
+     * Creates pending intent to attach with click actions on carousel images. Each image shown
+     * in the carousel will have a separate click action. Default action will be app open.
+     *
+     * @param context valid context object
+     * @param message valid message object
+     * @param element corresponding carousel element
+     * @return {@link PendingIntent}
+     */
+    private PendingIntent getCarouselImageClickPendingIntent(Context context, Message message, CarouselElement element) {
+        String action = RichPushConstants.buildAction(context, element.getAction());
+        Intent bcIntent = new Intent(action);
+
+        bcIntent.putExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, message.getCategory().getNotificationId());
+        bcIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+        bcIntent.putExtra(RichPushConstants.EXTRA_CAROUSEL_ELEMENT, element);
+
+        return PendingIntent.getBroadcast(context, 0, bcIntent, PendingIntent.FLAG_ONE_SHOT);
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -129,7 +129,7 @@ public class Message implements Serializable {
     /**
      * Optional additional data as key value pair.
      */
-    private HashMap<String, Object> data;
+    private HashMap data;
 
     /**
      * The following are the get / set methods for the above declared variables.
@@ -220,7 +220,7 @@ public class Message implements Serializable {
         return image_url;
     }
 
-    public HashMap<String, Object> getData() {
+    public HashMap getData() {
         return data;
     }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
@@ -11,6 +11,7 @@ public final class RichPushConstants {
     public static final String EXTRA_MESSAGE = "message";
     public static final String EXTRA_NOTIFICATION_ID = "notification_id";
     public static final String EXTRA_CAROUSEL_INDEX = "carousel_index";
+    public static final String EXTRA_CAROUSEL_ELEMENT = "carousel_element";
 
     /**
      * Actions for the push categories handled by SDK.


### PR DESCRIPTION
## Changes: ##
- Added separate click action support for each carousel element.
- If action is not present, default action will be app open (`ACTION_OPEN_APP`).
- Added `HashMap` `data` inside `Message` and `CarouselElement` for passing extra data.
- Supported actions are
  - ACTION_VIEW
  - ACTION_BUY
  - ACTION_OPEN_CART
  - ACTION_OPEN_OFFER_PAGE
  - ACTION_OPEN_APP

Sample JSON for carousel element
```json
{
  "image_url" : "http://image.jpg",
  "action" : "ACTION_BUY",
  "data" : {
    "string_key" : "sample string",
    "string_array" : [ "item_1" , "item_2" ],
    "object" : { "key" : "value" }
  }
}
```
The above carousel element tells to open the cart page and will pass the `Message` and `CarouselElement` object as `Bundle` extras into the activity, when clicked on the carousel image.

More details check this link with supported actions.
https://github.com/blueshift-labs/Blueshift-Android-SDK/wiki/Push-Notifications-&-Alerts#2-override-notification-action-receiver