### PR TITLE
Handle show dialog issue fix

### DIFF
--- a/android-sdk/src/main/AndroidManifest.xml
+++ b/android-sdk/src/main/AndroidManifest.xml
@@ -9,11 +9,14 @@
 
         <activity
             android:name=".rich_push.NotificationActivity"
-            android:label=""
+            android:configChanges="orientation|screenSize"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:taskAffinity=":BsftNotificationDialog"
             android:theme="@style/TransparentActivity" />
 
         <!--Events batching-->
-        <receiver android:name="com.blueshift.batch.AlarmReceiver"/>
+        <receiver android:name="com.blueshift.batch.AlarmReceiver" />
         <!--End - Events batching-->
 
         <!--App install tracking-->

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -102,7 +102,6 @@ public class NotificationActivity extends AppCompatActivity {
                         PackageManager packageManager = getPackageManager();
                         Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
                         launcherIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, mMessage);
-                        launcherIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(launcherIntent);
 
                         Blueshift.getInstance(mContext).trackNotificationPageOpen(mMessage, true);

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -88,12 +88,13 @@ public class RichPushNotification {
 
                 @Override
                 protected void onPostExecute(Boolean appIsInForeground) {
-                    Log.d(LOG_TAG, "App is in " + (appIsInForeground ? "foreground." : "background."));
-
                     Intent notificationIntent = new Intent(context, NotificationActivity.class);
                     notificationIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
                     notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
+                    /**
+                     * Clear the stack only if the app is in background / killed.
+                     */
                     if (!appIsInForeground) {
                         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
                     }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -1,5 +1,6 @@
 package com.blueshift.rich_push;
 
+import android.app.ActivityManager;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -10,6 +11,7 @@ import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.support.v7.app.NotificationCompat;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.blueshift.Blueshift;
 import com.blueshift.model.Configuration;
@@ -17,6 +19,7 @@ import com.blueshift.util.SdkLog;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -75,13 +78,53 @@ public class RichPushNotification {
         }
     }
 
-    private static void buildAndShowAlertDialog(Context context, Message message) {
+    private static void buildAndShowAlertDialog(final Context context, final Message message) {
         if (context != null && message != null) {
-            Intent notificationIntent = new Intent(context, NotificationActivity.class);
-            notificationIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
-            notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            context.startActivity(notificationIntent);
+            new AsyncTask<Void, Void, Boolean>() {
+                @Override
+                protected Boolean doInBackground(Void... params) {
+                    return isAppInForeground(context);
+                }
+
+                @Override
+                protected void onPostExecute(Boolean appIsInForeground) {
+                    Log.d(LOG_TAG, "App is in " + (appIsInForeground ? "foreground." : "background."));
+
+                    Intent notificationIntent = new Intent(context, NotificationActivity.class);
+                    notificationIntent.putExtra(RichPushConstants.EXTRA_MESSAGE, message);
+                    notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                    if (!appIsInForeground) {
+                        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                    }
+
+                    context.startActivity(notificationIntent);
+                }
+            }.execute();
         }
+    }
+
+    private static boolean isAppInForeground(Context context) {
+        boolean isAppInForeground = false;
+
+        if (context != null) {
+            ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            List<ActivityManager.RunningAppProcessInfo> appProcesses = activityManager.getRunningAppProcesses();
+            if (appProcesses != null) {
+                String packageName = context.getPackageName();
+                for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+                    if (appProcess != null
+                            && appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                            && appProcess.processName.equals(packageName)) {
+
+                        isAppInForeground = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return isAppInForeground;
     }
 
     private static void buildAndShowNotification(Context context, Message message) {


### PR DESCRIPTION
### Issue:
When the dialog type notification arrives while the app is in background, the app was being brought to front.

### Fixed - Current behavior
If the app is in background or killed, we will show only the dialog with a transparent background. If the app is in foreground, dialog will be shown on top of it.