### PR TITLE
Synchronization on db class Instantiation

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/batch/EventsTable.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/EventsTable.java
@@ -32,11 +32,13 @@ public class EventsTable extends BaseSqliteTable<Event> {
     }
 
     public static EventsTable getInstance(Context context) {
-        if (sInstance == null) {
-            sInstance = new EventsTable(context);
-        }
+        synchronized (lock) {
+            if (sInstance == null) {
+                sInstance = new EventsTable(context);
+            }
 
-        return sInstance;
+            return sInstance;
+        }
     }
 
     @Override

--- a/android-sdk/src/main/java/com/blueshift/batch/FailedEventsTable.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/FailedEventsTable.java
@@ -35,11 +35,13 @@ public class FailedEventsTable extends BaseSqliteTable<Event> {
     }
 
     public static FailedEventsTable getInstance(Context context) {
-        if (sInstance == null) {
-            sInstance = new FailedEventsTable(context);
-        }
+        synchronized (lock) {
+            if (sInstance == null) {
+                sInstance = new FailedEventsTable(context);
+            }
 
-        return sInstance;
+            return sInstance;
+        }
     }
 
     @Override

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
@@ -62,7 +62,7 @@ public class RequestQueue {
 
             RequestQueueTable db = RequestQueueTable.getInstance(mContext);
             db.insert(request);
-            db.close();
+
             sync();
         }
     }
@@ -73,7 +73,6 @@ public class RequestQueue {
 
             RequestQueueTable db = RequestQueueTable.getInstance(mContext);
             db.delete(request);
-            db.close();
         }
     }
 
@@ -82,10 +81,7 @@ public class RequestQueue {
             mStatus = Status.BUSY;
 
             RequestQueueTable db = RequestQueueTable.getInstance(mContext);
-            Request request = db.getNextRequest();
-            db.close();
-
-            return request;
+            return db.getNextRequest();
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueTable.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueTable.java
@@ -40,11 +40,13 @@ public class RequestQueueTable extends BaseSqliteTable<Request> {
     }
 
     public static RequestQueueTable getInstance(Context context) {
-        if (sInstance == null) {
-            sInstance = new RequestQueueTable(context);
-        }
+        synchronized (lock) {
+            if (sInstance == null) {
+                sInstance = new RequestQueueTable(context);
+            }
 
-        return sInstance;
+            return sInstance;
+        }
     }
 
     @Override


### PR DESCRIPTION
The `getInstance()` method of the db helper classes are synchronized using the same lock variable we use to lock the db operations.

The `.close()` call on the db helper instances used in `RequestQueue` class is removed as the db is getting closed once the db operations are complete.