### PR TITLE
New API for notification click and delivery events

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -42,6 +42,7 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
+        buildConfigField 'String', 'SDK_VERSION',  '"0.7.7"'
     }
     buildTypes {
         release {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -280,18 +280,35 @@ public class Blueshift {
                 return false;
             } else {
                 if (params != null) {
-                    // For the events click and view for notifications calls
-                    // a different API. We don't need to add device details
-                    // to that API.
+                    /**
+                     * The notification events 'click' and 'delivered' are now being sent to a
+                     * different API.
+                     *
+                     * We don't need to add device details to this new API. Hence processing it
+                     * separately.
+                     */
                     String eventName = (String) params.get(BlueshiftConstants.KEY_EVENT);
                     if (isNotificationTrackEvent(eventName)) {
-                        // add key "a" to the hash (action)
                         HashMap<String, Object> eventParams = new HashMap<>();
                         eventParams.put(BlueshiftConstants.KEY_ACTION, eventName);
                         eventParams.put(BlueshiftConstants.KEY_UID, params.get(Message.EXTRA_BSFT_USER_UUID));
                         eventParams.put(BlueshiftConstants.KEY_EID, params.get(Message.EXTRA_BSFT_EXPERIMENT_UUID));
-                        eventParams.put(BlueshiftConstants.KEY_TXNID, params.get(Message.EXTRA_BSFT_TRANSACTIONAL_UUID));
-                        eventParams.put(BlueshiftConstants.KEY_MID, params.get(BlueshiftConstants.KEY_NOTIFICATION_ID));
+
+                        Object txnUuidObj = params.get(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
+                        if (txnUuidObj != null) {
+                            String txnUuid = (String) txnUuidObj;
+                            if (!TextUtils.isEmpty(txnUuid)) {
+                                eventParams.put(BlueshiftConstants.KEY_TXNID, txnUuid);
+                            }
+                        }
+
+                        Object msgUuidObj = params.get(BlueshiftConstants.KEY_NOTIFICATION_ID);
+                        if (msgUuidObj != null) {
+                            String messageUuid = (String) msgUuidObj;
+                            if (!TextUtils.isEmpty(messageUuid)) {
+                                eventParams.put(BlueshiftConstants.KEY_MID, messageUuid);
+                            }
+                        }
 
                         // Add Sdk version to the params
                         eventParams.put(BlueshiftConstants.KEY_SDK_VERSION, BuildConfig.SDK_VERSION);

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -933,7 +933,7 @@ public class Blueshift {
 
             String paramsUrl = getUrlParams(eventParams);
             if (!TextUtils.isEmpty(paramsUrl)) {
-                String reqUrl = BlueshiftConstants.NOTIFICATION_EVENT_API_URL + "?" + paramsUrl;
+                String reqUrl = BlueshiftConstants.TRACK_API_URL + "?" + paramsUrl;
 
                 Request request = new Request();
                 request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -305,7 +305,7 @@ public class Blueshift {
                             }
 
                             if (userInfo.getRetailerCustomerId() != null) {
-                                requestParams.put(BlueshiftConstants.KEY_RETAILER_CUSTOMER_ID, userInfo.getRetailerCustomerId());
+                                requestParams.put(BlueshiftConstants.KEY_CUSTOMER_ID, userInfo.getRetailerCustomerId());
                             } else {
                                 Log.w(LOG_TAG, "Retailer customer id found missing in UserInfo.");
                             }
@@ -463,7 +463,7 @@ public class Blueshift {
             Log.w(LOG_TAG, "identifyUserByCustomerId() - The retailer customer ID provided is empty.");
         }
 
-        identifyUser(BlueshiftConstants.KEY_RETAILER_CUSTOMER_ID, customerId, details, canBatchThisEvent);
+        identifyUser(BlueshiftConstants.KEY_CUSTOMER_ID, customerId, details, canBatchThisEvent);
     }
 
     /**
@@ -811,7 +811,7 @@ public class Blueshift {
 
     public void trackNotificationView(String notificationId, HashMap<String, Object> params) {
         HashMap<String, Object> eventParams = new HashMap<>();
-        eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
+        eventParams.put(BlueshiftConstants.KEY_MESSAGE_UUID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
@@ -834,7 +834,7 @@ public class Blueshift {
 
     public void trackNotificationClick(String notificationId, HashMap<String, Object> params) {
         HashMap<String, Object> eventParams = new HashMap<>();
-        eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
+        eventParams.put(BlueshiftConstants.KEY_MESSAGE_UUID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
@@ -857,7 +857,7 @@ public class Blueshift {
 
     public void trackNotificationPageOpen(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
         HashMap<String, Object> eventParams = new HashMap<>();
-        eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
+        eventParams.put(BlueshiftConstants.KEY_MESSAGE_UUID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
@@ -880,7 +880,7 @@ public class Blueshift {
 
     public void trackAlertDismiss(String notificationId, HashMap<String, Object> params, boolean canBatchThisEvent) {
         HashMap<String, Object> eventParams = new HashMap<>();
-        eventParams.put(BlueshiftConstants.KEY_NOTIFICATION_ID, notificationId);
+        eventParams.put(BlueshiftConstants.KEY_MESSAGE_UUID, notificationId);
 
         if (params != null) {
             eventParams.putAll(params);
@@ -920,7 +920,7 @@ public class Blueshift {
                 }
             }
 
-            Object msgUuidObj = params.get(BlueshiftConstants.KEY_NOTIFICATION_ID);
+            Object msgUuidObj = params.get(BlueshiftConstants.KEY_MESSAGE_UUID);
             if (msgUuidObj != null) {
                 String messageUuid = (String) msgUuidObj;
                 if (!TextUtils.isEmpty(messageUuid)) {

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -58,7 +58,7 @@ public class BlueshiftConstants {
 
     // User
     public static final String KEY_EMAIL = "email";
-    public static final String KEY_RETAILER_CUSTOMER_ID = "retailer_customer_id";
+    public static final String KEY_CUSTOMER_ID = "customer_id";
     public static final String KEY_FIRST_NAME = "firstname";
     public static final String KEY_LAST_NAME = "lastname";
     public static final String KEY_GENDER = "gender";
@@ -91,7 +91,7 @@ public class BlueshiftConstants {
     public static final String KEY_SUBSCRIPTION_AMOUNT = "subscription_amount";
     public static final String KEY_SUBSCRIPTION_START_DATE = "subscription_start_date";
     public static final String KEY_SUBSCRIPTION_STATUS = "subscription_status";
-    public static final String KEY_NOTIFICATION_ID = "message_uuid";
+    public static final String KEY_MESSAGE_UUID = "message_uuid";
     public static final String KEY_TIMESTAMP = "timestamp";
     public static final String KEY_SDK_VERSION = "sdk_version";
     public static final String KEY_UID = "uid";

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -10,10 +10,11 @@ public class BlueshiftConstants {
     /**
      * URLs for server communication
      */
-    public static final String BASE_URL = "https://api.getblueshift.com/api/v1";
-    public static final String EVENT_API_URL = BASE_URL + "/event";
-    public static final String BULK_EVENT_API_URL = BASE_URL + "/bulkevents";
-    public static final String NOTIFICATION_EVENT_API_URL = "https://api.getblueshift.com/track";
+    public static final String BASE_URL = "https://api.getblueshift.com";
+    public static final String TRACK_API_URL = BASE_URL + "/track";
+    public static final String V1_API_URL = BASE_URL + "/api/v1";
+    public static final String EVENT_API_URL = V1_API_URL + "/event";
+    public static final String BULK_EVENT_API_URL = V1_API_URL + "/bulkevents";
 
     /**
      * Event names sent to Blueshift server

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -13,6 +13,7 @@ public class BlueshiftConstants {
     public static final String BASE_URL = "https://api.getblueshift.com/api/v1";
     public static final String EVENT_API_URL = BASE_URL + "/event";
     public static final String BULK_EVENT_API_URL = BASE_URL + "/bulkevents";
+    public static final String NOTIFICATION_EVENT_API_URL = "https://api.getblueshift.com/track";
 
     /**
      * Event names sent to Blueshift server
@@ -34,7 +35,7 @@ public class BlueshiftConstants {
     public static final String EVENT_SUBSCRIPTION_CANCEL = "subscription_cancel";
     public static final String EVENT_APP_OPEN = "app_open";
     public static final String EVENT_APP_INSTALL = "app_install";
-    public static final String EVENT_PUSH_VIEW  = "open";
+    public static final String EVENT_PUSH_DELIVERED = "delivered";
     public static final String EVENT_PUSH_CLICK  = "click";
     public static final String EVENT_DISMISS_ALERT = "dismiss_alert";
 
@@ -89,8 +90,14 @@ public class BlueshiftConstants {
     public static final String KEY_SUBSCRIPTION_AMOUNT = "subscription_amount";
     public static final String KEY_SUBSCRIPTION_START_DATE = "subscription_start_date";
     public static final String KEY_SUBSCRIPTION_STATUS = "subscription_status";
-    public static final String KEY_NOTIFICATION_ID = "notification_id";
+    public static final String KEY_NOTIFICATION_ID = "message_uuid";
     public static final String KEY_TIMESTAMP = "timestamp";
+    public static final String KEY_SDK_VERSION = "sdk_version";
+    public static final String KEY_UID = "uid";
+    public static final String KEY_MID = "mid";
+    public static final String KEY_EID = "eid";
+    public static final String KEY_TXNID = "txnid";
+    public static final String KEY_ACTION = "a";
 
     /**
      * Subscription status values

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
@@ -194,6 +194,12 @@ public class RequestQueue {
                         response = httpManager.post(mRequest.getParamJson());
                         break;
 
+                    case GET:
+                        SdkLog.d(LOG_TAG, "Request URL: " + mRequest.getUrl());
+
+                        response = httpManager.get();
+                        break;
+
                     default:
                         SdkLog.e(LOG_TAG, "Unknown method" + mRequest.getMethod());
                 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -73,7 +73,7 @@ public class CustomNotificationFactory {
                 manager.notify(message.getCategory().getNotificationId(), notification);
 
                 // Tracking the notification display.
-                Blueshift.getInstance(context).trackNotificationView(message, true);
+                Blueshift.getInstance(context).trackNotificationView(message);
             }
         }
     }
@@ -114,7 +114,7 @@ public class CustomNotificationFactory {
 
                 if (!isUpdating) {
                     // Tracking the notification display for the first time
-                    Blueshift.getInstance(context).trackNotificationView(message, true);
+                    Blueshift.getInstance(context).trackNotificationView(message);
                 }
             }
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -14,7 +14,7 @@ public class Message implements Serializable {
     public static final String EXTRA_MESSAGE = "message";
     public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
     public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
-    public static final String EXTRA_BSFT_TRANSACTIONAL_UUID = "transactional_uuid";
+    public static final String EXTRA_BSFT_TRANSACTIONAL_UUID = "bsft_transaction_uuid";
 
     /**
      * Following are the campaign uuids. They come outside the 'message' object in push message.
@@ -23,6 +23,7 @@ public class Message implements Serializable {
      */
     private String bsft_experiment_uuid;
     private String bsft_user_uuid;
+    private String bsft_transaction_uuid; // present only with transactional campaign
 
     /**
      * The following variables are used for parsing the 'message' payload.
@@ -33,12 +34,7 @@ public class Message implements Serializable {
      * id used for tracking the notification events
      */
     private String message_uuid;
-
-    /**
-     * This value will be present only for transactional campaign
-     */
-    private String transactional_uuid;
-
+    
     /**
      * ** mandatory **
      * used for defining the type of notification. currently takes 2 values.
@@ -179,8 +175,8 @@ public class Message implements Serializable {
             attributes.put(EXTRA_BSFT_EXPERIMENT_UUID, getBsftExperimentUuid());
             attributes.put(EXTRA_BSFT_USER_UUID, getBsftUserUuid());
 
-            if (!TextUtils.isEmpty(getTransactionalUuid())) {
-                attributes.put(EXTRA_BSFT_TRANSACTIONAL_UUID, getTransactionalUuid());
+            if (!TextUtils.isEmpty(getBsftTransactionUuid())) {
+                attributes.put(EXTRA_BSFT_TRANSACTIONAL_UUID, getBsftTransactionUuid());
             }
         }
 
@@ -191,8 +187,12 @@ public class Message implements Serializable {
         return message_uuid;
     }
 
-    public String getTransactionalUuid() {
-        return transactional_uuid;
+    public String getBsftTransactionUuid() {
+        return bsft_transaction_uuid;
+    }
+
+    public void setBsftTransactionUuid(String transactionUuid) {
+        this.bsft_transaction_uuid = transactionUuid;
     }
 
     public NotificationType getNotificationType() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -14,6 +14,7 @@ public class Message implements Serializable {
     public static final String EXTRA_MESSAGE = "message";
     public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
     public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
+    public static final String EXTRA_BSFT_TRANSACTIONAL_UUID = "transactional_uuid";
 
     /**
      * Following are the campaign uuids. They come outside the 'message' object in push message.
@@ -31,7 +32,12 @@ public class Message implements Serializable {
     /**
      * id used for tracking the notification events
      */
-    private String id;
+    private String message_uuid;
+
+    /**
+     * This value will be present only for transactional campaign
+     */
+    private String transactional_uuid;
 
     /**
      * ** mandatory **
@@ -172,13 +178,21 @@ public class Message implements Serializable {
             attributes = new HashMap<>();
             attributes.put(EXTRA_BSFT_EXPERIMENT_UUID, getBsftExperimentUuid());
             attributes.put(EXTRA_BSFT_USER_UUID, getBsftUserUuid());
+
+            if (!TextUtils.isEmpty(getTransactionalUuid())) {
+                attributes.put(EXTRA_BSFT_TRANSACTIONAL_UUID, getTransactionalUuid());
+            }
         }
 
         return attributes;
     }
 
     public String getId() {
-        return id;
+        return message_uuid;
+    }
+
+    public String getTransactionalUuid() {
+        return transactional_uuid;
     }
 
     public NotificationType getNotificationType() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -78,7 +78,7 @@ public class NotificationActivity extends AppCompatActivity {
             builder.create().show();
 
             // Tracking the notification display.
-            Blueshift.getInstance(mContext).trackNotificationView(mMessage, true);
+            Blueshift.getInstance(mContext).trackNotificationView(mMessage);
         } else {
             finish();
         }
@@ -97,7 +97,7 @@ public class NotificationActivity extends AppCompatActivity {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
 
-                        Blueshift.getInstance(mContext).trackNotificationClick(mMessage, true);
+                        Blueshift.getInstance(mContext).trackNotificationClick(mMessage);
 
                         PackageManager packageManager = getPackageManager();
                         Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -54,7 +54,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                     (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.cancel(intent.getIntExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, 0));
 
-            Blueshift.getInstance(context).trackNotificationClick(message, true);
+            Blueshift.getInstance(context).trackNotificationClick(message);
 
             context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
         } else {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -29,10 +29,12 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
                     // trying to fetch campaign params
                     String experimentUUID = intent.getStringExtra(Message.EXTRA_BSFT_EXPERIMENT_UUID);
                     String userUUID = intent.getStringExtra(Message.EXTRA_BSFT_USER_UUID);
+                    String txnUUID = intent.getStringExtra(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
 
                     // adding campaign parameters inside message.
                     message.setBsftExperimentUuid(experimentUUID);
                     message.setBsftUserUuid(userUUID);
+                    message.setBsftTransactionUuid(txnUUID);
 
                     if (message.isSilentPush()) {
                         /**

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -225,7 +225,7 @@ public class RichPushNotification {
             notificationManager.notify(notificationID, builder.build());
 
             // Tracking the notification display.
-            Blueshift.getInstance(context).trackNotificationView(message, true);
+            Blueshift.getInstance(context).trackNotificationView(message);
         }
     }
 


### PR DESCRIPTION
This PR is an implementation of a significant change on the flow of notification click/view events. Both the events are now being sent to a different end point. The sample URLs are given below.

https://api.getblueshift.com/track?a=delivered&txnid=111222333&uid=qwertyuiop&mid=888666888&sdk_version=0.7.7&eid=asdfghjkl

https://api.getblueshift.com/track?a=click&txnid=111222333&uid=qwertyuiop&mid=888666888&sdk_version=0.7.7&eid=asdfghjkl

These events are treated as real-time events even though the other events called by sdk are batchable.

From now on, the events parameter will have one more key called sdk_verison which contains the latest version name of the sdk.

Here is the template used for testing.

```json
{
  "data": {
    "bsft_user_uuid":"qwertyuiop",
    "bsft_experiment_uuid":"asdfghjkl",
    "message": {
      "message_uuid": "888666888",
      "transactional_uuid" : "111222333",
      "notification_type": "notification",
      "category": "promotion",
      "content_title": "Google Nexus 5x",
      "content_text": "This is your chance to get the brand new nexus 5x at a dream price.",
      "content_sub_text": "Get your device today!",
      "big_content_title": "Don't miss the deal!",
      "big_content_summary_text": "Grab your Nexus 5x today!"
    }
  },
  "registration_ids": [
  	"APA91bHLVzGAlMR_...NkYB"
  ]
}
```