### PR TITLE
Handling notification and data messages

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -1,7 +1,19 @@
 package com.blueshift.fcm;
 
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.support.v4.app.NotificationCompat;
+import android.text.TextUtils;
 import android.util.Log;
 
+import com.blueshift.Blueshift;
+import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.Message;
 import com.blueshift.rich_push.RichPushNotification;
 import com.blueshift.util.SdkLog;
@@ -11,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Rahul Raveendran V P
@@ -24,15 +37,99 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
-        Map<String, String> data = remoteMessage.getData();
-        if (data != null) {
-            handleMessage(data);
+        RemoteMessage.Notification notification = remoteMessage.getNotification();
+
+        /**
+         * If notification payload is present, consider that.
+         */
+        if (notification != null) {
+            Map<String, String> data = remoteMessage.getData();
+            handleNotificationMessage(notification, data);
         } else {
-            super.onMessageReceived(remoteMessage);
+            /**
+             * If data payload is present, follow the regular notification flow.
+             */
+            Map<String, String> data = remoteMessage.getData();
+            if (data != null) {
+                handleDataMessage(data);
+            } else {
+                /**
+                 * Neither data nor notification payload is present
+                 */
+                super.onMessageReceived(remoteMessage);
+            }
         }
     }
 
-    private void handleMessage(Map<String, String> data) {
+    private void handleNotificationMessage(RemoteMessage.Notification notification, Map<String, String> data) {
+        if (notification != null) {
+            PackageManager packageManager = getPackageManager();
+
+            Intent launcherIntent = packageManager.getLaunchIntentForPackage(getPackageName());
+            launcherIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+            /**
+             * Add the data payload to the intent's extra
+             */
+            if (data != null) {
+                Set<String> keySet = data.keySet();
+                for (String key : keySet) {
+                    launcherIntent.putExtra(key, data.get(key));
+                }
+            }
+
+            /**
+             * Create pending intent for notification click action
+             */
+            PendingIntent pendingIntent = PendingIntent.getActivity(this,
+                    RichPushNotification.getRandomPIRequestCode(),
+                    launcherIntent,
+                    PendingIntent.FLAG_ONE_SHOT);
+
+            /**
+             * Create the notification title. User defined / app name / "Notification"
+             */
+            String titleText = notification.getTitle();
+
+            if (TextUtils.isEmpty(titleText)) {
+                try {
+                    ApplicationInfo info = packageManager.getApplicationInfo(getPackageName(), 0);
+                    if (info != null) {
+                        titleText = packageManager.getApplicationLabel(info).toString();
+                    }
+                } catch (PackageManager.NameNotFoundException e) {
+                    Log.e(LOG_TAG, e.getMessage());
+                }
+            }
+
+            if (TextUtils.isEmpty(titleText)) {
+                titleText = "Notification";
+            }
+
+            /**
+             * Create simple notification.
+             */
+            Configuration configuration = Blueshift.getInstance(this).getConfiguration();
+            Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
+                    .setSmallIcon(configuration.getSmallIconResId())
+                    .setContentTitle(titleText)
+                    .setContentText(notification.getBody())
+                    .setAutoCancel(true)
+                    .setSound(defaultSoundUri)
+                    .setContentIntent(pendingIntent);
+
+            NotificationManager notificationManager =
+                    (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+            notificationManager.notify(
+                    RichPushNotification.getRandomPIRequestCode(), notificationBuilder.build());
+
+            // TODO: 4/1/17 Decide on how to track this one.
+        }
+    }
+
+    private void handleDataMessage(Map<String, String> data) {
         if (data != null) {
             String msgJson = data.get(Message.EXTRA_MESSAGE);
             if (msgJson != null) {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -32,8 +32,8 @@ public class RichPushNotification {
 
     private final static Random sRandom = new Random();
 
-    static int getRandomPIRequestCode() {
-        return sRandom.nextInt();
+    public static int getRandomPIRequestCode() {
+        return sRandom.nextInt(Integer.MAX_VALUE);
     }
 
     public static void handleMessage(final Context context, final Message message) {


### PR DESCRIPTION
There are two types of payloads that can come with FCM push.

1. notification
2. data

The sdk have access to the `onMessageReceived` method only as per [this document](https://firebase.google.com/docs/cloud-messaging/android/receive) says.

When app is in foreground and a `notification` msg comes with or without `data`, we're rendering notification based on the payload came with `notification` key. If `data` is present, it will be added to the launcher intent's extras (like the FCM do for msgs with both notification and data payload when app is in background)