### PR TITLE
Push Payload Key Position Change

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
@@ -203,7 +203,7 @@ public class RequestQueue {
                         response = httpManager.get();
 
                         Log.d(LOG_TAG, "Blueshift Event\n" +
-                                "Method: GET" +
+                                "Method: GET\n" +
                                 "URL: " + mRequest.getUrl() + "\n" +
                                 "Status: " + getStatusFromResponse(response)
                         );

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -15,6 +15,7 @@ public class Message implements Serializable {
     public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
     public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
     public static final String EXTRA_BSFT_TRANSACTIONAL_UUID = "bsft_transaction_uuid";
+    public static final String EXTRA_BSFT_MESSAGE_UUID = "bsft_message_uuid";
 
     /**
      * Following are the campaign uuids. They come outside the 'message' object in push message.
@@ -33,8 +34,8 @@ public class Message implements Serializable {
     /**
      * id used for tracking the notification events
      */
-    private String message_uuid;
-    
+    private String bsft_message_uuid;
+
     /**
      * ** mandatory **
      * used for defining the type of notification. currently takes 2 values.
@@ -184,7 +185,11 @@ public class Message implements Serializable {
     }
 
     public String getId() {
-        return message_uuid;
+        return bsft_message_uuid;
+    }
+
+    public void setBsftMessageUuid(String bsft_message_uuid) {
+        this.bsft_message_uuid = bsft_message_uuid;
     }
 
     public String getBsftTransactionUuid() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -27,9 +27,13 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
                 Message message = new Gson().fromJson(messageJSON, Message.class);
                 if (message != null) {
                     // trying to fetch campaign params
+                    String msgUUID = intent.getStringExtra(Message.EXTRA_BSFT_MESSAGE_UUID);
                     String experimentUUID = intent.getStringExtra(Message.EXTRA_BSFT_EXPERIMENT_UUID);
                     String userUUID = intent.getStringExtra(Message.EXTRA_BSFT_USER_UUID);
                     String txnUUID = intent.getStringExtra(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
+
+                    // adding message uuid
+                    message.setBsftMessageUuid(msgUUID);
 
                     // adding campaign parameters inside message.
                     message.setBsftExperimentUuid(experimentUUID);

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -32,10 +32,8 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
                     String userUUID = intent.getStringExtra(Message.EXTRA_BSFT_USER_UUID);
                     String txnUUID = intent.getStringExtra(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
 
-                    // adding message uuid
-                    message.setBsftMessageUuid(msgUUID);
-
                     // adding campaign parameters inside message.
+                    message.setBsftMessageUuid(msgUUID);
                     message.setBsftExperimentUuid(experimentUUID);
                     message.setBsftUserUuid(userUUID);
                     message.setBsftTransactionUuid(txnUUID);


### PR DESCRIPTION
`bsft_message_uuid` key location changed in the push payload. this key is coming outside the `message` object now.

New payload (See PR #40 comments):

```json
{
  "data": {
    "bsft_user_uuid":"qwertyuiop",
    "bsft_experiment_uuid":"asdfghjkl",
    "bsft_transaction_uuid":"zxcvbnm",
    "bsft_message_uuid": "888666888",
    "message": {
      "notification_type": "notification",
      "category": "promotion",
      "content_title": "Google Nexus 5x",
      "content_text": "This is your chance to get the brand new nexus 5x at a dream price.",
      "content_sub_text": "Get your device today!",
      "big_content_title": "Don't miss the deal!",
      "big_content_summary_text": "Grab your Nexus 5x today!"
    }
  },
  "registration_ids": [
    "APA91bGZ3G597-t4JepyhDh...YUBwao1Syt5ggurNgh"
  ]
}
```