### PR TITLE
Live Content API 

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -22,8 +22,10 @@ import com.blueshift.batch.BulkEventManager;
 import com.blueshift.batch.Event;
 import com.blueshift.batch.EventsTable;
 import com.blueshift.gcm.GCMRegistrar;
+import com.blueshift.httpmanager.HTTPManager;
 import com.blueshift.httpmanager.Method;
 import com.blueshift.httpmanager.Request;
+import com.blueshift.httpmanager.Response;
 import com.blueshift.httpmanager.request_queue.RequestQueue;
 import com.blueshift.model.Configuration;
 import com.blueshift.model.Product;
@@ -143,6 +145,44 @@ public class Blueshift {
         }
 
         return status;
+    }
+
+    public void loadLiveContent(final HashMap<String, Object> reqParams, final LiveContentCallback callback) {
+        new AsyncTask<Void, Void, String>() {
+            @Override
+            protected String doInBackground(Void... params) {
+                String responseStr = null;
+
+                Configuration configuration = getConfiguration();
+                if (configuration != null) {
+                    HTTPManager httpManager = new HTTPManager(BlueshiftConstants.LIVE_CONTENT_API_URL);
+                    httpManager.addBasicAuthentication("", configuration.getApiKey());
+
+                    if (reqParams != null) {
+                        // TODO: 13/1/17 add params in req.
+                    }
+
+                    Response response = httpManager.get();
+                    switch (response.getStatusCode()) {
+                        case 0:
+                            responseStr = "No internet.";
+                            break;
+
+                        default:
+                            responseStr = response.getResponseBody();
+                    }
+                }
+
+                return responseStr;
+            }
+
+            @Override
+            protected void onPostExecute(String response) {
+                if (callback != null) {
+                    callback.onReceive(response);
+                }
+            }
+        }.execute();
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -147,42 +147,8 @@ public class Blueshift {
         return status;
     }
 
-    public void loadLiveContent(final HashMap<String, Object> reqParams, final LiveContentCallback callback) {
-        new AsyncTask<Void, Void, String>() {
-            @Override
-            protected String doInBackground(Void... params) {
-                String responseStr = null;
-
-                Configuration configuration = getConfiguration();
-                if (configuration != null) {
-                    HTTPManager httpManager = new HTTPManager(BlueshiftConstants.LIVE_CONTENT_API_URL);
-                    httpManager.addBasicAuthentication("", configuration.getApiKey());
-
-                    if (reqParams != null) {
-                        // TODO: 13/1/17 add params in req.
-                    }
-
-                    Response response = httpManager.get();
-                    switch (response.getStatusCode()) {
-                        case 0:
-                            responseStr = "No internet.";
-                            break;
-
-                        default:
-                            responseStr = response.getResponseBody();
-                    }
-                }
-
-                return responseStr;
-            }
-
-            @Override
-            protected void onPostExecute(String response) {
-                if (callback != null) {
-                    callback.onReceive(response);
-                }
-            }
-        }.execute();
+    public void getLiveContent(@NotNull String slot, LiveContentCallback callback) {
+        new FetchLiveContentTask(mContext, slot, callback).execute();
     }
 
     /**
@@ -1072,6 +1038,69 @@ public class Blueshift {
                 updateAndroidAdId(adId);
             } else {
                 SdkLog.w(LOG_TAG, "Could not fetch AdvertisingId");
+            }
+        }
+    }
+
+    /**
+     * Async task that fetched live content from Bsft server
+     */
+    private class FetchLiveContentTask extends AsyncTask<Void, Void, String> {
+        private final Context mContext;
+        private final String mSlot;
+        private final LiveContentCallback mCallback;
+
+        FetchLiveContentTask(Context context, String slot, LiveContentCallback callback) {
+            mContext = context;
+            mSlot = slot;
+            mCallback = callback;
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            String responseJson = null;
+
+            HashMap<String, String> reqParams = new HashMap<>();
+            if (!TextUtils.isEmpty(mSlot)) {
+                reqParams.put(BlueshiftConstants.KEY_SLOT, mSlot);
+            } else {
+                Log.e(LOG_TAG, "Live Content Api: No slot provided.");
+            }
+
+            Configuration config = getConfiguration();
+            if (config != null) {
+                String apiKey = config.getApiKey();
+                if (!TextUtils.isEmpty(apiKey)) {
+                    reqParams.put(BlueshiftConstants.KEY_API_KEY, apiKey);
+                } else {
+                    Log.e(LOG_TAG, "Live Content Api: No Api Key provided.");
+                }
+            } else {
+                Log.e(LOG_TAG, "Live Content Api: No valid config provided.");
+            }
+
+            UserInfo userInfo = UserInfo.getInstance(mContext);
+            String email = userInfo.getEmail();
+            if (!TextUtils.isEmpty(email)) {
+                reqParams.put(BlueshiftConstants.KEY_EMAIL_ID, email);
+            } else {
+                Log.e(LOG_TAG, "Live Content Api: No email provided.");
+            }
+
+            HTTPManager httpManager = new HTTPManager(BlueshiftConstants.LIVE_CONTENT_API_URL);
+            Response response = httpManager.get(reqParams);
+
+            if (response.getStatusCode() == 200) {
+                responseJson = response.getResponseBody();
+            }
+
+            return responseJson;
+        }
+
+        @Override
+        protected void onPostExecute(String json) {
+            if (mCallback != null) {
+                mCallback.onReceive(json);
             }
         }
     }

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -108,7 +108,6 @@ public class BlueshiftConstants {
     // live content
     public static final String KEY_SLOT = "slot";
     public static final String KEY_API_KEY = "x";
-    public static final String KEY_EMAIL_ID = "email";
 
     /**
      * Subscription status values

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -12,10 +12,10 @@ public class BlueshiftConstants {
      */
     public static final String BASE_URL = "https://api.getblueshift.com";
     public static final String TRACK_API_URL = BASE_URL + "/track";
+    public static final String LIVE_CONTENT_API_URL = BASE_URL + "/live";
     public static final String V1_API_URL = BASE_URL + "/api/v1";
     public static final String EVENT_API_URL = V1_API_URL + "/event";
     public static final String BULK_EVENT_API_URL = V1_API_URL + "/bulkevents";
-    public static final String LIVE_CONTENT_API_URL = V1_API_URL + "/bulkevents"; // // TODO: 13/1/17 Add new api
 
     /**
      * Event names sent to Blueshift server
@@ -38,7 +38,7 @@ public class BlueshiftConstants {
     public static final String EVENT_APP_OPEN = "app_open";
     public static final String EVENT_APP_INSTALL = "app_install";
     public static final String EVENT_PUSH_DELIVERED = "delivered";
-    public static final String EVENT_PUSH_CLICK  = "click";
+    public static final String EVENT_PUSH_CLICK = "click";
     public static final String EVENT_DISMISS_ALERT = "dismiss_alert";
 
     /**
@@ -104,6 +104,11 @@ public class BlueshiftConstants {
     public static final String KEY_EID = "eid";
     public static final String KEY_TXNID = "txnid";
     public static final String KEY_ACTION = "a";
+
+    // live content
+    public static final String KEY_SLOT = "slot";
+    public static final String KEY_API_KEY = "x";
+    public static final String KEY_EMAIL_ID = "email";
 
     /**
      * Subscription status values

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -15,6 +15,7 @@ public class BlueshiftConstants {
     public static final String V1_API_URL = BASE_URL + "/api/v1";
     public static final String EVENT_API_URL = V1_API_URL + "/event";
     public static final String BULK_EVENT_API_URL = V1_API_URL + "/bulkevents";
+    public static final String LIVE_CONTENT_API_URL = V1_API_URL + "/bulkevents"; // // TODO: 13/1/17 Add new api
 
     /**
      * Event names sent to Blueshift server

--- a/android-sdk/src/main/java/com/blueshift/LiveContentCallback.java
+++ b/android-sdk/src/main/java/com/blueshift/LiveContentCallback.java
@@ -1,6 +1,10 @@
 package com.blueshift;
 
 /**
+ * This interface provides a callback method 'onReceive()' which is
+ * used by the live content API inside Blueshift sdk. It is responsible
+ * for delivering the api response received from the server to the caller.
+ *
  * @author Rahul Raveendran V P
  *         Created on 13/1/17 @ 3:16 PM
  *         https://github.com/rahulrvp

--- a/android-sdk/src/main/java/com/blueshift/LiveContentCallback.java
+++ b/android-sdk/src/main/java/com/blueshift/LiveContentCallback.java
@@ -1,0 +1,11 @@
+package com.blueshift;
+
+/**
+ * @author Rahul Raveendran V P
+ *         Created on 13/1/17 @ 3:16 PM
+ *         https://github.com/rahulrvp
+ */
+
+public interface LiveContentCallback {
+    void onReceive(String response);
+}


### PR DESCRIPTION
This PR adds a new API to the SDK, `getLiveContent()`. This API is responsible for delivering live content based on the provided slot (campaign name).

Here is the sample code for using the `getLiveContent()` API.

```java
Blueshift
        .getInstance(mContext)
        .getLiveContent("Editors_Picks_Json", new LiveContentCallback() {
            @Override
            public void onReceive(String json) {
                // use the json and do stuff.
            }
        });
```