### PR TITLE
outdated gps app crash

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -31,12 +31,12 @@ ext {
 // ANDROID
 // =================================================================================================
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -58,9 +58,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.1.0'
     // for Android Advertising Id
-    compile 'com.google.android.gms:play-services-ads:9.6.1'
+    compile 'com.google.android.gms:play-services-ads:10.2.0'
     // for JSON parsing
     compile 'com.google.code.gson:gson:2.6.1'
     // for annotations used (ex @NotNull)

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -62,7 +62,7 @@ public class DeviceUtils {
             }
         } catch (IOException e) {
             SdkLog.e(LOG_TAG, libNotFoundMessage + "\n" + e.getMessage());
-        } catch (GooglePlayServicesNotAvailableException e) {
+        } catch (GooglePlayServicesNotAvailableException | IllegalStateException e) {
             Log.e(LOG_TAG, libNotFoundMessage);
             installNewGooglePlayServicesApp(context);
         } catch (GooglePlayServicesRepairableException e) {


### PR DESCRIPTION
The client app was throwing an `IllegalStateException` if there is a mismatch in the Google Play Service's version. We're now catching the exception and asking the end-user to install the updated version of GPS app.

In this PR, we have also increased the version of support library, play-services library and also the target and build sdks'.