### PR TITLE
added null check to value of all the getMessage() calls in the sdk.

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -220,7 +220,7 @@ public class Blueshift {
                         try {
                             pkgInfo = pkgManager.getPackageInfo(pkgName, 0);
                         } catch (PackageManager.NameNotFoundException e) {
-                            Log.e(LOG_TAG, e.getMessage());
+                            Log.e(LOG_TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
                         }
 
                         if (pkgInfo != null && pkgInfo.versionName != null) {
@@ -234,7 +234,7 @@ public class Blueshift {
                         try {
                             appInfo = pkgManager.getApplicationInfo(pkgName, 0);
                         } catch (PackageManager.NameNotFoundException e) {
-                            Log.e(LOG_TAG, e.getMessage());
+                            Log.e(LOG_TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
                         }
 
                         CharSequence appName = "Not Available";

--- a/android-sdk/src/main/java/com/blueshift/gcm/GCMBaseIntentService.java
+++ b/android-sdk/src/main/java/com/blueshift/gcm/GCMBaseIntentService.java
@@ -103,7 +103,7 @@ public abstract class GCMBaseIntentService extends IntentService {
             Log.v(TAG, "Intent service name: " + name);
             return name;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return "";
@@ -114,7 +114,7 @@ public abstract class GCMBaseIntentService extends IntentService {
             String flatSenderIds = GCMRegistrar.getFlatSenderIds(senderIds);
             return getName(flatSenderIds);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return "";
@@ -147,7 +147,7 @@ public abstract class GCMBaseIntentService extends IntentService {
             intent.setClassName(context, className);
             context.startService(intent);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -358,7 +358,7 @@ public abstract class GCMBaseIntentService extends IntentService {
                 onError(context, error);
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/gcm/GCMBroadcastReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/gcm/GCMBroadcastReceiver.java
@@ -56,7 +56,7 @@ public class GCMBroadcastReceiver extends BroadcastReceiver {
             GCMBaseIntentService.runIntentInService(context, intent, className);
             setResult(Activity.RESULT_OK, null /* data */, null /* extra */);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/gcm/GCMIntentService.java
+++ b/android-sdk/src/main/java/com/blueshift/gcm/GCMIntentService.java
@@ -37,7 +37,7 @@ public class GCMIntentService extends GCMBaseIntentService {
             bcIntent.putExtras(intent.getExtras());
             sendBroadcast(bcIntent);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -46,7 +46,7 @@ public class GCMIntentService extends GCMBaseIntentService {
         try {
             Log.i(TAG, "Error code: " + errorId);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -80,7 +80,7 @@ public class GCMIntentService extends GCMBaseIntentService {
                 }
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -89,7 +89,7 @@ public class GCMIntentService extends GCMBaseIntentService {
         try {
             Log.i(TAG, "Device unregistered");
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/gcm/GCMRegistrar.java
+++ b/android-sdk/src/main/java/com/blueshift/gcm/GCMRegistrar.java
@@ -103,7 +103,7 @@ public final class GCMRegistrar {
                 Log.e(TAG, "GCM registration failed.");
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -136,7 +136,7 @@ public final class GCMRegistrar {
 
             return true;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
 
             return false;
         }
@@ -248,7 +248,7 @@ public final class GCMRegistrar {
 
             return true;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
 
             return false;
         }
@@ -280,7 +280,7 @@ public final class GCMRegistrar {
                 }
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -303,7 +303,7 @@ public final class GCMRegistrar {
             GCMRegistrar.resetBackoff(context);
             internalRegister(context, senderIds);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -319,7 +319,7 @@ public final class GCMRegistrar {
             intent.putExtra(GCMConstants.EXTRA_SENDER, flatSenderIds);
             context.startService(intent);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -355,7 +355,7 @@ public final class GCMRegistrar {
 
             return builder.toString();
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return "";
@@ -375,7 +375,7 @@ public final class GCMRegistrar {
             GCMRegistrar.resetBackoff(context);
             internalUnregister(context);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -396,7 +396,7 @@ public final class GCMRegistrar {
                 sRetryReceiver = null;
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -409,7 +409,7 @@ public final class GCMRegistrar {
                     PendingIntent.getBroadcast(context, 0, new Intent(), 0));
             context.startService(intent);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -446,7 +446,7 @@ public final class GCMRegistrar {
                 context.registerReceiver(sRetryReceiver, filter, permission, null);
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -486,7 +486,7 @@ public final class GCMRegistrar {
                 return registrationId;
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return "";
@@ -530,7 +530,7 @@ public final class GCMRegistrar {
                 return oldRegistrationId;
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return "";
@@ -554,7 +554,7 @@ public final class GCMRegistrar {
                 editor.apply();
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -587,7 +587,7 @@ public final class GCMRegistrar {
 
             return isRegistered;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return false;
@@ -611,7 +611,7 @@ public final class GCMRegistrar {
 
             return lifespan;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return DEFAULT_ON_SERVER_LIFESPAN_MS;
@@ -630,7 +630,7 @@ public final class GCMRegistrar {
                 editor.apply();
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -660,7 +660,7 @@ public final class GCMRegistrar {
             Log.d(TAG, "resetting backoff for " + context.getPackageName());
             setBackoff(context, DEFAULT_BACKOFF_MS);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -677,7 +677,7 @@ public final class GCMRegistrar {
                 return prefs.getInt(BACKOFF_MS, DEFAULT_BACKOFF_MS);
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return DEFAULT_BACKOFF_MS;
@@ -701,7 +701,7 @@ public final class GCMRegistrar {
                 editor.apply();
             }
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -709,7 +709,7 @@ public final class GCMRegistrar {
         try {
             return context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
 
         return null;

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueue.java
@@ -165,7 +165,7 @@ public class RequestQueue {
 
                         mRequest.setParamJson(jsonObject.toString());
                     } catch (JSONException e) {
-                        Log.e(LOG_TAG, e.getMessage());
+                        Log.e(LOG_TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
                     }
 
                     UserInfo userInfo = UserInfo.getInstance(mContext);

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -359,7 +359,8 @@ public class CustomNotificationFactory {
                         );
                     }
                 } catch (IOException e) {
-                    SdkLog.e(LOG_TAG, "Could not download image. " + e.getMessage());
+                    String logMessage = e.getMessage() != null ? e.getMessage() : "";
+                    SdkLog.e(LOG_TAG, "Could not download image. " + logMessage);
                 }
             }
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushBroadcastReceiver.java
@@ -52,7 +52,8 @@ public class RichPushBroadcastReceiver extends BroadcastReceiver {
                     Log.e(LOG_TAG, "Null message found in push message.");
                 }
             } catch (JsonSyntaxException e) {
-                Log.e(LOG_TAG, "Invalid JSON in push message: " + e.getMessage());
+                String logMessage = e.getMessage() != null ? e.getMessage() : "";
+                Log.e(LOG_TAG, "Invalid JSON in push message: " + logMessage);
             }
         } else {
             SdkLog.d(LOG_TAG, "Message not found. Passing the push message to host app via broadcast.");

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -203,7 +203,8 @@ public class RichPushNotification {
                         builder.setStyle(bigPictureStyle);
                     }
                 } catch (IOException e) {
-                    SdkLog.e(LOG_TAG, "Could not load image. " + e.getMessage());
+                    String logMessage = e.getMessage() != null ? e.getMessage() : "";
+                    SdkLog.e(LOG_TAG, "Could not load image. " + logMessage);
                 }
             } else {
                 // enable big text style

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -42,7 +42,7 @@ public class DeviceUtils {
             gpsInstallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(gpsInstallIntent);
         } catch (ActivityNotFoundException e) {
-            Log.e(LOG_TAG, e.getMessage());
+            Log.e(LOG_TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
         }
     }
 
@@ -61,7 +61,8 @@ public class DeviceUtils {
                 advertisingId = info.getId();
             }
         } catch (IOException e) {
-            SdkLog.e(LOG_TAG, libNotFoundMessage + "\n" + e.getMessage());
+            String logMessage = e.getMessage() != null ? e.getMessage() : "";
+            SdkLog.e(LOG_TAG, libNotFoundMessage + "\n" + logMessage);
         } catch (GooglePlayServicesNotAvailableException | IllegalStateException e) {
             Log.e(LOG_TAG, libNotFoundMessage);
             installNewGooglePlayServicesApp(context);

--- a/android-sdk/src/main/java/com/blueshift/util/SdkLog.java
+++ b/android-sdk/src/main/java/com/blueshift/util/SdkLog.java
@@ -31,6 +31,6 @@ public class SdkLog {
     }
 
     public static void e(String tag, String message) {
-        if (isDebug) Log.e(tag, message);
+        if (isDebug) Log.e(tag, message != null ? message : "Unknown error!");
     }
 }


### PR DESCRIPTION
Fix to Issue #56

The app was crashing when logging the result of a e.getMessage() call inside the gcm lib.

A null check is added for the same line and all the other possible areas in the sdk to avoid any future occurrence of the same kind of error.