### PR TITLE
Variable number of Carousel Elements

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -34,7 +34,7 @@ import java.util.Locale;
  * <p>
  * Created by Rahul on 16/9/16.
  */
-public class CustomNotificationFactory {
+class CustomNotificationFactory {
 
     private static final String LOG_TAG = "NotificationFactory";
 
@@ -59,7 +59,7 @@ public class CustomNotificationFactory {
      * @param context valid context object.
      * @param message message object with valid carousel elements.
      */
-    public void createAndShowAnimatedCarousel(Context context, Message message) {
+    void createAndShowAnimatedCarousel(Context context, Message message) {
         if (context != null && message != null) {
             int notificationId = RichPushNotification.getRandomNotificationId();
 
@@ -89,7 +89,7 @@ public class CustomNotificationFactory {
      * @param context valid context object.
      * @param message message object with valid carousel elements.
      */
-    public void createAndShowCarousel(Context context, Message message) {
+    void createAndShowCarousel(Context context, Message message) {
         int notificationId = RichPushNotification.getRandomNotificationId();
         createAndShowCarousel(context, message, false, 0, notificationId);
     }
@@ -102,7 +102,7 @@ public class CustomNotificationFactory {
      * @param isUpdating  flag to indicate id the notification should be created or updated
      * @param targetIndex index of the image to be shown in carousel - carousel element index
      */
-    public void createAndShowCarousel(Context context, Message message, boolean isUpdating, int targetIndex, int notificationId) {
+    void createAndShowCarousel(Context context, Message message, boolean isUpdating, int targetIndex, int notificationId) {
         if (context != null && message != null) {
             NotificationCompat.Builder builder = createBasicNotification(context, message, isUpdating, notificationId);
             if (builder != null) {

--- a/android-sdk/src/main/res/layout/carousel_image_view.xml
+++ b/android-sdk/src/main/res/layout/carousel_image_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/carousel_image_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:contentDescription="@string/carousel_image"
+    android:scaleType="centerCrop" />

--- a/android-sdk/src/main/res/layout/carousel_layout.xml
+++ b/android-sdk/src/main/res/layout/carousel_layout.xml
@@ -21,9 +21,11 @@
             android:scaleType="centerCrop"
             android:visibility="gone" />
 
-        <include
+        <LinearLayout
             android:id="@+id/animated_carousel_view"
-            layout="@layout/carousel_view_flipper"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
             android:visibility="gone" />
 
         <ImageButton

--- a/android-sdk/src/main/res/layout/carousel_view_flipper.xml
+++ b/android-sdk/src/main/res/layout/carousel_view_flipper.xml
@@ -1,42 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/viewFlipper"
+    android:id="@+id/view_flipper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:autoStart="true"
     android:inAnimation="@android:anim/fade_in"
-    android:outAnimation="@android:anim/fade_out">
-
-    <ImageView
-        android:id="@+id/carousel_picture1"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:scaleType="centerCrop"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/carousel_picture2"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:scaleType="centerCrop"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/carousel_picture3"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:scaleType="centerCrop"
-        android:visibility="gone" />
-
-    <ImageView
-        android:id="@+id/carousel_picture4"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="bottom"
-        android:scaleType="centerCrop"
-        android:visibility="gone" />
-
-</ViewFlipper>
+    android:outAnimation="@android:anim/fade_out" />

--- a/android-sdk/src/main/res/values/strings.xml
+++ b/android-sdk/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="carousel_next_button">Carousel next button</string>
     <string name="big_picture">Big picture</string>
     <string name="gps_not_found_msg">Could not fetch Advertising ID!\nPlease make sure that Google Play services 4.0+ or Google Mobile Ads lib is included in your project.\nVisit \"https://developer.android.com/google/play-services/setup.html\" for more help.</string>
+    <string name="carousel_image">Carousel image</string>
 </resources>


### PR DESCRIPTION
The number of carousel elements were fixed to 4 in the sdk.

This patch will remove that restriction and will let the payload decide how many carousel elements to be shown in notification.

It is recommended to keep an upper limit at the server end as downloading too many images may lead to delayed notification or memory issues.