### PR TITLE
Make default channel name configurable

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -118,7 +118,8 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
             Configuration configuration = Blueshift.getInstance(this).getConfiguration();
             Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 
-            String channelId = NotificationUtils.getNotificationChannelId(RichPushConstants.DEFAULT_CHANNEL_NAME);
+            String channelName = NotificationUtils.getNotificationChannelName(this, null);
+            String channelId = NotificationUtils.getNotificationChannelId(channelName);
 
             NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, channelId)
                     .setSmallIcon(configuration.getSmallIconResId())
@@ -134,7 +135,7 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
             if (notificationManager != null) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     NotificationChannel channel =
-                            NotificationUtils.createNotificationChannel(null);
+                            NotificationUtils.createNotificationChannel(this,null);
                     if (channel != null) {
                         notificationManager.createNotificationChannel(channel);
                     }

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -25,6 +25,8 @@ public class Configuration {
     private int smallIconResId;
     private int largeIconResId;
     private int notificationColor;
+    private String defaultNotificationChannelName;
+    private String defaultNotificationChannelDescription;
 
     public Configuration() {
         batchInterval = AlarmManager.INTERVAL_HALF_HOUR;
@@ -125,5 +127,21 @@ public class Configuration {
      */
     public void setNotificationColor(int notificationColor) {
         this.notificationColor = notificationColor;
+    }
+
+    public String getDefaultNotificationChannelName() {
+        return defaultNotificationChannelName;
+    }
+
+    public void setDefaultNotificationChannelName(String channelName) {
+        this.defaultNotificationChannelName = channelName;
+    }
+
+    public String getDefaultNotificationChannelDescription() {
+        return defaultNotificationChannelDescription;
+    }
+
+    public void setDefaultNotificationChannelDescription(String channelDescription) {
+        this.defaultNotificationChannelDescription = channelDescription;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -78,7 +78,7 @@ class CustomNotificationFactory {
                 if (manager != null) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         NotificationChannel channel =
-                                NotificationUtils.createNotificationChannel(message);
+                                NotificationUtils.createNotificationChannel(context, message);
                         if (channel != null) {
                             manager.createNotificationChannel(channel);
                         }
@@ -129,7 +129,7 @@ class CustomNotificationFactory {
                 if (manager != null) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         NotificationChannel channel =
-                                NotificationUtils.createNotificationChannel(message);
+                                NotificationUtils.createNotificationChannel(context, message);
                         if (channel != null) {
                             manager.createNotificationChannel(channel);
                         }
@@ -354,7 +354,8 @@ class CustomNotificationFactory {
         if (context != null && message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null) {
-                String channelId = NotificationUtils.getNotificationChannelId(message.getNotificationChannelName());
+                String channelName = NotificationUtils.getNotificationChannelName(context, message);
+                String channelId = NotificationUtils.getNotificationChannelId(channelName);
                 builder = new NotificationCompat.Builder(context, channelId);
                 builder.setDefaults(Notification.DEFAULT_ALL);
                 builder.setAutoCancel(true);

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -369,9 +369,7 @@ public class Message implements Serializable {
     }
 
     public String getNotificationChannelName() {
-        return
-                TextUtils.isEmpty(notification_channel_name) ?
-                        RichPushConstants.DEFAULT_CHANNEL_NAME : notification_channel_name;
+        return notification_channel_name;
     }
 
     public String getNotificationChannelDescription() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushNotification.java
@@ -129,8 +129,9 @@ public class RichPushNotification {
         if (context != null && message != null) {
             int notificationId = RichPushNotification.getRandomNotificationId();
 
-            String channelId = NotificationUtils.getNotificationChannelId(
-                    message.getNotificationChannelName());
+            String channelName = NotificationUtils.getNotificationChannelName(context, message);
+            String channelId = NotificationUtils.getNotificationChannelId(channelName);
+
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);
             builder.setDefaults(Notification.DEFAULT_SOUND);
             builder.setAutoCancel(true);
@@ -254,7 +255,7 @@ public class RichPushNotification {
             if (notificationManager != null) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     NotificationChannel channel =
-                            NotificationUtils.createNotificationChannel(message);
+                            NotificationUtils.createNotificationChannel(context, message);
                     if (channel != null) {
                         notificationManager.createNotificationChannel(channel);
                     }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -10,6 +10,8 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
+import com.blueshift.Blueshift;
+import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.CarouselElement;
 import com.blueshift.rich_push.Message;
 import com.blueshift.rich_push.RichPushConstants;
@@ -185,25 +187,71 @@ public class NotificationUtils {
     }
 
     /**
+     * Read default channel name from config if provided. If not return "General" as
+     * channel name.
+     *
+     * @param context valid Context object
+     * @param message message object to read the channel name from
+     * @return valid notification channel name
+     */
+    public static String getNotificationChannelName(Context context, Message message) {
+        String channelName = RichPushConstants.DEFAULT_CHANNEL_NAME;
+
+        if (message != null && !TextUtils.isEmpty(message.getNotificationChannelName())) {
+            channelName = message.getNotificationChannelName();
+        } else {
+            if (context != null) {
+                Blueshift blueshift = Blueshift.getInstance(context);
+                Configuration config = blueshift.getConfiguration();
+                if (config != null) {
+                    String channelNameStr = config.getDefaultNotificationChannelName();
+                    if (!TextUtils.isEmpty(channelNameStr)) {
+                        channelName = channelNameStr;
+                    }
+                }
+            }
+        }
+
+        return channelName;
+    }
+
+    /**
+     * Reads a channel description from the config object
+     *
+     * @param context valid context object
+     * @param message message object to read the channel name from
+     * @return valid channel description if provided, else null
+     */
+    public static String getNotificationChannelDescription(Context context, Message message) {
+        String channelDescription = null;
+
+        if (message != null && !TextUtils.isEmpty(message.getNotificationChannelDescription())) {
+            channelDescription = message.getNotificationChannelDescription();
+        } else {
+            if (context != null) {
+                Blueshift blueshift = Blueshift.getInstance(context);
+                Configuration config = blueshift.getConfiguration();
+                if (config != null) {
+                    channelDescription = config.getDefaultNotificationChannelName();
+                }
+            }
+        }
+
+        return channelDescription;
+    }
+
+    /**
      * Creates a channel object with default details. This is required for Oreo to show Notification.
      *
      * @param message valid Message object
      * @return valid NotificationChannel object
      */
-    public static NotificationChannel createNotificationChannel(Message message) {
+    public static NotificationChannel createNotificationChannel(Context context, Message message) {
         NotificationChannel channel = null;
 
-        // read channel name from payload
-        String channelName = RichPushConstants.DEFAULT_CHANNEL_NAME;
-        String channelDescription = null;
-
-        if (message != null) {
-            // read channel name from payload if available.
-            channelName = message.getNotificationChannelName();
-
-            // read channel description. set    to exact same value present in payload.
-            channelDescription = message.getNotificationChannelDescription();
-        }
+        // read channel name & description from config/message
+        String channelName = getNotificationChannelName(context, message);
+        String channelDescription = getNotificationChannelDescription(context, message);
 
         // create channel id
         String channelId = getNotificationChannelId(channelName);


### PR DESCRIPTION
The default channel name is General. The developer is allowed to change that to any string after this change.

priority level : from payload -> from config -> default (General)