### PR TITLE
Possible Serialisation Crash Catching

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -32,7 +32,10 @@ public class NotificationActivity extends AppCompatActivity {
 
         mContext = this;
 
-        mMessage = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+        try {
+            mMessage = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+        } catch (Exception ignore) {
+        }
 
         if (mMessage != null) {
             int theme = 0;

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
@@ -35,7 +35,13 @@ public class NotificationWorker extends IntentService {
 
         if (action == null) return;
 
-        Message message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+        Message message = null;
+        try {
+            message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+        } catch (Exception ignore) {
+        }
+
+        if (message == null) return;
 
         switch (action) {
             case ACTION_CAROUSEL_IMG_CHANGE:

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -46,7 +46,13 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                 SdkLog.d(LOG_TAG, "No bundle data available with the broadcast.");
             }
 
-            Message message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+            Message message = null;
+            try {
+                message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+            } catch (Exception ignore) {
+            }
+
+            if (message == null) return;
 
             // remove cached images(if any) for this notification
             NotificationUtils.removeCachedCarouselImages(context, message);


### PR DESCRIPTION
In some devices getSerializableExtra() crashes. This PR adds crash handling by catching the exception and ignoring the same.