### PR TITLE
Remove static Context object from RequestQueue

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1,6 +1,7 @@
 package com.blueshift;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
@@ -30,6 +31,7 @@ import com.blueshift.model.UserInfo;
 import com.blueshift.rich_push.Message;
 import com.blueshift.type.SubscriptionState;
 import com.blueshift.util.DeviceUtils;
+import com.blueshift.util.PermissionUtils;
 import com.blueshift.util.SdkLog;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.gson.Gson;
@@ -375,12 +377,17 @@ public class Blueshift {
                         // setting the last known location parameters.
                         LocationManager locationManager = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
                         if (locationManager != null) {
-                            if (hasPermission(mContext, Manifest.permission.ACCESS_FINE_LOCATION)
-                                    || hasPermission(mContext, Manifest.permission.ACCESS_COARSE_LOCATION)) {
+                            if (PermissionUtils.hasAnyPermission(mContext,
+                                    new String[]{
+                                            Manifest.permission.ACCESS_FINE_LOCATION,
+                                            Manifest.permission.ACCESS_COARSE_LOCATION})) {
+
                                 // We have either of the above 2 permissions granted.
 
-                                // noinspection MissingPermission (because permission check is done above)
-                                Location location = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+                                @SuppressLint("MissingPermission")
+                                Location location =
+                                        locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+
                                 if (location != null) {
                                     requestParams.put(BlueshiftConstants.KEY_LATITUDE, location.getLatitude());
                                     requestParams.put(BlueshiftConstants.KEY_LONGITUDE, location.getLongitude());
@@ -416,7 +423,7 @@ public class Blueshift {
                             SdkLog.i(LOG_TAG, "Adding real-time event to request queue.");
 
                             // Adding the request to the queue.
-                            RequestQueue.getInstance(mContext).add(request);
+                            RequestQueue.getInstance().add(mContext, request);
                         }
 
                         return true;
@@ -1038,7 +1045,7 @@ public class Blueshift {
                 SdkLog.i(LOG_TAG, "Adding real-time event to request queue.");
 
                 // Adding the request to the queue.
-                RequestQueue.getInstance(mContext).add(request);
+                RequestQueue.getInstance().add(mContext, request);
 
                 return true;
             } else {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -242,7 +242,7 @@ public class Blueshift {
         // Collect app details
         initAppInfo(mContext);
         // Sync the http request queue.
-        RequestQueue.getInstance(mContext).sync();
+        RequestQueue.getInstance().sync(mContext);
         // schedule job to sync request queue on nw change
         RequestQueue.scheduleQueueSyncJob(mContext);
         // schedule the bulk events dispatch

--- a/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -211,7 +211,7 @@ public class BulkEventManager {
             request.setParamJson(new Gson().toJson(bulkEvent));
 
             // Adding the request to the queue.
-            RequestQueue.getInstance(context).add(request);
+            RequestQueue.getInstance().add(context, request);
         }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
@@ -24,7 +24,6 @@ public class RequestQueueJobService extends JobService {
     @Override
     public boolean onStartJob(final JobParameters jobParameters) {
         mReqQueueSyncTask = new RequestQueueSyncTask(
-                getApplicationContext(),
                 new RequestQueueSyncTask.Callback() {
                     @Override
                     public void onTaskStart() {
@@ -40,7 +39,7 @@ public class RequestQueueJobService extends JobService {
                     }
                 });
 
-        mReqQueueSyncTask.execute();
+        mReqQueueSyncTask.execute(getApplicationContext());
 
         return true;
     }

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueSyncTask.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueSyncTask.java
@@ -11,12 +11,12 @@ import android.os.AsyncTask;
  */
 
 
-public class RequestQueueSyncTask extends AsyncTask<Void, Void, Void> {
+public class RequestQueueSyncTask extends AsyncTask<Context, Void, Void> {
     private RequestQueue mRequestQueue;
     private Callback mCallback;
 
-    public RequestQueueSyncTask(Context context, Callback callback) {
-        mRequestQueue = RequestQueue.getInstance(context);
+    public RequestQueueSyncTask(Callback callback) {
+        mRequestQueue = RequestQueue.getInstance();
         mCallback = callback;
     }
 
@@ -28,9 +28,9 @@ public class RequestQueueSyncTask extends AsyncTask<Void, Void, Void> {
     }
 
     @Override
-    protected Void doInBackground(Void... voids) {
-        if (mRequestQueue != null) {
-            mRequestQueue.sync();
+    protected Void doInBackground(Context... contexts) {
+        if (mRequestQueue != null && contexts != null && contexts.length > 0) {
+            mRequestQueue.sync(contexts[0]);
         }
 
         return null;

--- a/android-sdk/src/main/java/com/blueshift/receiver/NetworkChangeListener.java
+++ b/android-sdk/src/main/java/com/blueshift/receiver/NetworkChangeListener.java
@@ -24,7 +24,7 @@ public class NetworkChangeListener extends BroadcastReceiver {
         if (context != null && intent != null
                 && "android.net.conn.CONNECTIVITY_CHANGE".equals(intent.getAction())) {
             // call the db sync task to send events to server
-            new RequestQueueSyncTask(context, null).execute();
+            new RequestQueueSyncTask(null).execute(context);
         }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/NetworkUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NetworkUtils.java
@@ -1,5 +1,11 @@
 package com.blueshift.util;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -22,7 +28,7 @@ public class NetworkUtils {
             httpURLConnection = (HttpURLConnection) downloadURL.openConnection();
             httpURLConnection.connect();
 
-            if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK ) {
+            if (httpURLConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
                 return false;
             }
 
@@ -56,5 +62,24 @@ public class NetworkUtils {
         }
 
         return true;
+    }
+
+    public static boolean isConnected(Context context) {
+        boolean hasNetwork = false;
+
+        if (context != null &&
+                PermissionUtils.hasPermission(context, Manifest.permission.ACCESS_NETWORK_STATE)) {
+
+            ConnectivityManager connectivityManager =
+                    (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+            if (connectivityManager != null) {
+                @SuppressLint("MissingPermission")
+                NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+                hasNetwork = networkInfo != null && networkInfo.isConnectedOrConnecting();
+            }
+        }
+
+        return hasNetwork;
     }
 }


### PR DESCRIPTION
Removed the static instance of Context class from RequestQueue. Still, the AsyncTask inside RequestQueue has a member variable which is Context. This will be removed later when request queue event firing is optimized.

Note: The PR#79 should be reviewed and merged before this PR.