### PR TITLE
app_open event firing made configurable

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -266,6 +266,10 @@ public class Blueshift {
         RequestQueue.scheduleQueueSyncJob(mContext);
         // schedule the bulk events dispatch
         BulkEventManager.scheduleBulkEventEnqueue(mContext);
+        // fire an app open automatically if enabled
+        if (mConfiguration != null && mConfiguration.isAutoAppOpenFiringEnabled()) {
+            trackAppOpen(true);
+        }
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -33,6 +33,8 @@ public class Configuration {
     private int networkChangeListenerJobId;
     private int bulkEventsJobId;
 
+    private boolean enableAutoAppOpen = false;
+
     public Configuration() {
         batchInterval = AlarmManager.INTERVAL_HALF_HOUR;
         networkChangeListenerJobId = 901;
@@ -174,5 +176,21 @@ public class Configuration {
 
     public void setBulkEventsJobId(int bulkEventsJobId) {
         this.bulkEventsJobId = bulkEventsJobId;
+    }
+
+    public boolean isAutoAppOpenFiringEnabled() {
+        return enableAutoAppOpen;
+    }
+
+    /**
+     * This enables/disables the app_open event firing when app is started based on the boolean
+     * value supplied in enableAutoAppOpen.
+     *
+     * By default the automatic firing of app_open is disabled.
+     *
+     * @param enableAutoAppOpen boolean value that enable/disable auto app open firing.
+     */
+    public void setEnableAutoAppOpenFiring(boolean enableAutoAppOpen) {
+        this.enableAutoAppOpen = enableAutoAppOpen;
     }
 }


### PR DESCRIPTION
Added a method inside configuration that help us decide if we should fire the app_open automatically.

This app_open will only be fire when app is restarted. Bringing the app to foreground will not fire this event.