### PR TITLE
Timestamp fixes to match server requirements

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -115,19 +115,19 @@ public class InAppManager {
                                 params.put(BlueshiftConstants.KEY_EMAIL, email != null ? email : "");
 
                                 String messageUuid = null;
-                                long timestamp = 0;
+                                String lastTimestamp = null;
 
                                 InAppMessage inAppMessage = InAppMessageStore.getInstance(context).getLastInAppMessage();
                                 if (inAppMessage != null) {
                                     messageUuid = inAppMessage.getMessageUuid();
-                                    timestamp = inAppMessage.getTimestamp();
+                                    lastTimestamp = inAppMessage.getTimestamp();
                                 }
 
                                 // message uuid
                                 params.put(Message.EXTRA_BSFT_MESSAGE_UUID, messageUuid != null ? messageUuid : "");
 
-                                // timestamp
-                                params.put(BlueshiftConstants.KEY_LAST_TIMESTAMP, timestamp >= 0 ? timestamp : 0);
+                                // lastTimestamp
+                                params.put(BlueshiftConstants.KEY_LAST_TIMESTAMP, lastTimestamp != null ? lastTimestamp : 0);
 
                                 HTTPManager httpManager = new HTTPManager(BlueshiftConstants.IN_APP_API_URL);
 

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
@@ -39,7 +39,7 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
     private String experiment_uuid;
     private String user_uuid;
     private String transaction_uuid;
-    private long timestamp;
+    private String timestamp;
 
     public static InAppMessage getInstance(JSONObject jsonObject) {
         try {
@@ -60,10 +60,7 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
             inAppMessage.experiment_uuid = jsonObject.optString(Message.EXTRA_BSFT_EXPERIMENT_UUID);
             inAppMessage.user_uuid = jsonObject.optString(Message.EXTRA_BSFT_USER_UUID);
             inAppMessage.transaction_uuid = jsonObject.optString(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
-
-            // process timestamp
-            String timestampStr = jsonObject.optString(BlueshiftConstants.KEY_TIMESTAMP);
-            inAppMessage.timestamp = InAppUtils.timestampToEpochSeconds(timestampStr);
+            inAppMessage.timestamp = jsonObject.optString(BlueshiftConstants.KEY_TIMESTAMP);
 
             return inAppMessage;
         } catch (Exception e) {
@@ -92,10 +89,7 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
             inAppMessage.experiment_uuid = pushPayload.get(Message.EXTRA_BSFT_EXPERIMENT_UUID);
             inAppMessage.user_uuid = pushPayload.get(Message.EXTRA_BSFT_USER_UUID);
             inAppMessage.transaction_uuid = pushPayload.get(Message.EXTRA_BSFT_TRANSACTIONAL_UUID);
-
-            // process timestamp
-            String timestampStr = pushPayload.get(BlueshiftConstants.KEY_TIMESTAMP);
-            inAppMessage.timestamp = InAppUtils.timestampToEpochSeconds(timestampStr);
+            inAppMessage.timestamp = pushPayload.get(BlueshiftConstants.KEY_TIMESTAMP);
 
             return inAppMessage;
         } catch (Exception e) {
@@ -342,11 +336,11 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
         this.displayed_at = displayed_at;
     }
 
-    public long getTimestamp() {
+    public String getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(long timestamp) {
+    public void setTimestamp(String timestamp) {
         this.timestamp = timestamp;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageStore.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageStore.java
@@ -83,7 +83,7 @@ public class InAppMessageStore extends BlueshiftBaseSQLiteOpenHelper<InAppMessag
             inAppMessage.setUserUuid(getString(cursor, FIELD_USER_UUID));
             inAppMessage.setTransactionUuid(getString(cursor, FIELD_TRANSACTION_UUID));
             inAppMessage.setDisplayedAt(getLong(cursor, FIELD_TRANSACTION_UUID));
-            inAppMessage.setTimestamp(getLong(cursor, FIELD_TIMESTAMP));
+            inAppMessage.setTimestamp(getString(cursor, FIELD_TIMESTAMP));
 
             String tsJson = getString(cursor, FIELD_TEMPLATE_STYLE);
             if (!TextUtils.isEmpty(tsJson)) inAppMessage.setTemplateStyle(new JSONObject(tsJson));
@@ -145,7 +145,7 @@ public class InAppMessageStore extends BlueshiftBaseSQLiteOpenHelper<InAppMessag
         fieldTypeHashMap.put(FIELD_EXPERIMENT_UUID, FieldType.Text);
         fieldTypeHashMap.put(FIELD_USER_UUID, FieldType.Text);
         fieldTypeHashMap.put(FIELD_TRANSACTION_UUID, FieldType.Text);
-        fieldTypeHashMap.put(FIELD_TIMESTAMP, FieldType.Long);
+        fieldTypeHashMap.put(FIELD_TIMESTAMP, FieldType.Text);
         fieldTypeHashMap.put(FIELD_EXTRAS, FieldType.Text);
         fieldTypeHashMap.put(FIELD_DISPLAYED_AT, FieldType.Long);
         return fieldTypeHashMap;


### PR DESCRIPTION
send the timestamp received in the API response to the in-app API call unchanged. the default value expected by the server is 0.