### PR TITLE
Tweak the use of Advertising Id

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -253,7 +253,16 @@ public class Blueshift {
                         }
 
                         if (pkgInfo != null && pkgInfo.versionName != null) {
-                            String version = pkgInfo.versionName + " (" + pkgInfo.versionCode + ")";
+                            String versionName = pkgInfo.versionName;
+                            String versionCode;
+
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                                versionCode = String.valueOf(pkgInfo.getLongVersionCode());
+                            } else {
+                                versionCode = String.valueOf(pkgInfo.versionCode);
+                            }
+
+                            String version = versionName + " (" + versionCode + ")";
                             sAppParams.put(BlueshiftConstants.KEY_APP_VERSION, version);
                         }
 
@@ -466,6 +475,11 @@ public class Blueshift {
 
                         // adding timestamp
                         requestParams.put(BlueshiftConstants.KEY_TIMESTAMP, System.currentTimeMillis() / 1000);
+
+                        // get status of fresh device id & ad opt out
+                        // calling this synchronously as this method is called from a bg thread
+                        requestParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, DeviceUtils.getAdvertisingID(mContext));
+                        requestParams.put(BlueshiftConstants.KEY_LIMIT_AD_TRACKING, DeviceUtils.isLimitAdTrackingEnabled(mContext));
 
                         String reqParamsJSON = new Gson().toJson(requestParams);
 

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -51,6 +51,7 @@ public class BlueshiftConstants {
     public static final String KEY_APP_VERSION = "app_version";
 
     // Device
+    public static final String KEY_LIMIT_AD_TRACKING = "limit_ad_tracking";
     public static final String KEY_DEVICE_IDENTIFIER = "device_id";
     public static final String KEY_DEVICE_TYPE = "device_type";
     public static final String KEY_DEVICE_TOKEN = "device_token";

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -49,28 +49,47 @@ public class DeviceUtils {
     public static String getAdvertisingID(Context context) {
         String advertisingId = null;
 
-        String libNotFoundMessage = context.getString(R.string.gps_not_found_msg);
-
-        try {
-            AdvertisingIdClient.Info info = AdvertisingIdClient.getAdvertisingIdInfo(context);
+        if (!isLimitAdTrackingEnabled(context)) {
+            AdvertisingIdClient.Info info = getAdvertisingIdClientInfo(context);
             if (info != null) {
-                if (info.isLimitAdTrackingEnabled()) {
-                    Log.w(LOG_TAG, "User has limit ad tracking enabled.");
-                }
-
                 advertisingId = info.getId();
             }
-        } catch (IOException e) {
-            String logMessage = e.getMessage() != null ? e.getMessage() : "";
-            SdkLog.e(LOG_TAG, libNotFoundMessage + "\n" + logMessage);
-        } catch (GooglePlayServicesNotAvailableException | IllegalStateException e) {
-            Log.e(LOG_TAG, libNotFoundMessage);
-            installNewGooglePlayServicesApp(context);
-        } catch (GooglePlayServicesRepairableException e) {
-            SdkLog.e(LOG_TAG, e.getMessage());
         }
 
         return advertisingId;
+    }
+
+    public static boolean isLimitAdTrackingEnabled(Context context) {
+        boolean status = true; // by default the opt-out is turned ON
+
+        AdvertisingIdClient.Info info = getAdvertisingIdClientInfo(context);
+        if (info != null) {
+            status = info.isLimitAdTrackingEnabled();
+        }
+
+        return status;
+    }
+
+    private static AdvertisingIdClient.Info getAdvertisingIdClientInfo(Context context) {
+        AdvertisingIdClient.Info info = null;
+
+        if (context != null) {
+            String libNotFoundMessage = context.getString(R.string.gps_not_found_msg);
+
+            try {
+                info = AdvertisingIdClient.getAdvertisingIdInfo(context);
+            } catch (IOException e) {
+                String logMessage = e.getMessage() != null ? e.getMessage() : "";
+                SdkLog.e(LOG_TAG, libNotFoundMessage + "\n" + logMessage);
+            } catch (GooglePlayServicesNotAvailableException | IllegalStateException e) {
+                Log.e(LOG_TAG, libNotFoundMessage);
+                installNewGooglePlayServicesApp(context);
+            } catch (GooglePlayServicesRepairableException e) {
+                SdkLog.e(LOG_TAG, e.getMessage());
+            }
+        }
+
+        return info;
     }
 
     public static String getIP4Address() {


### PR DESCRIPTION
- If the `isLimitAdTrackingEnabled` is set to true, the SDK will no longer send the ad-id to the backend.

- To indicate `isLimitAdTrackingEnabled` is set to true, an attribute `limit_ad_tracking` will be sent to the backend with value true.