### PR TITLE
Enabled manual in-app trigger

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -24,6 +24,7 @@ import com.blueshift.httpmanager.HTTPManager;
 import com.blueshift.httpmanager.Method;
 import com.blueshift.httpmanager.Request;
 import com.blueshift.httpmanager.Response;
+import com.blueshift.inappmessage.InAppApiCallback;
 import com.blueshift.inappmessage.InAppConstants;
 import com.blueshift.inappmessage.InAppManager;
 import com.blueshift.inappmessage.InAppMessage;
@@ -89,6 +90,14 @@ public class Blueshift {
 
     public void unregisterForInAppMessages(Activity activity) {
         InAppManager.unregisterForInAppMessages(activity);
+    }
+
+    public void fetchInAppMessages(InAppApiCallback callback) {
+     InAppManager.fetchInAppFromServer(mContext, callback);
+    }
+
+    public void displayInAppMessages() {
+        InAppManager.invokeTriggers();
     }
 
     /**
@@ -319,7 +328,9 @@ public class Blueshift {
         InAppMessageIconFont.getInstance(mContext).updateFont(mContext);
 
         // fetch from API
-        InAppManager.fetchInAppFromServer(mContext);
+        if (mConfiguration != null && !mConfiguration.isInAppManualTriggerEnabled()) {
+            InAppManager.fetchInAppFromServer(mContext, null);
+        }
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -93,7 +93,7 @@ public class Blueshift {
     }
 
     public void fetchInAppMessages(InAppApiCallback callback) {
-     InAppManager.fetchInAppFromServer(mContext, callback);
+        InAppManager.fetchInAppFromServer(mContext, callback);
     }
 
     public void displayInAppMessages() {

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -238,7 +238,7 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
             if (inAppMessage != null) {
                 InAppManager.onInAppMessageReceived(this, inAppMessage);
                 InAppMessageStore.getInstance(this).clean();
-                InAppManager.invokeTriggers();
+                InAppManager.invokeTriggerWithinSdk();
             }
         } catch (Exception e) {
             BlueshiftLogger.e(LOG_TAG, e);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppApiCallback.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppApiCallback.java
@@ -1,0 +1,5 @@
+package com.blueshift.inappmessage;
+
+public interface InAppApiCallback {
+    void onApiCallComplete();
+}

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -113,7 +113,7 @@ public class InAppManager {
     public static void fetchInAppFromServer(final Context context, final InAppApiCallback callback) {
         boolean isEnabled = BlueshiftUtils.isInAppEnabled(context);
         if (isEnabled) {
-            final Handler finalHandler = getCallbackHandler(callback);
+            final Handler callbackHandler = getCallbackHandler(callback);
             BlueshiftExecutor.getInstance().runOnNetworkThread(
                     new Runnable() {
                         @Override
@@ -171,11 +171,11 @@ public class InAppManager {
                                     }
                                 }
 
-                                if (finalHandler != null) {
-                                    finalHandler.post(new Runnable() {
+                                if (callbackHandler != null && callback != null) {
+                                    callbackHandler.post(new Runnable() {
                                         @Override
                                         public void run() {
-                                            if (callback != null) callback.onApiCallComplete();
+                                            callback.onApiCallComplete();
                                         }
                                     });
                                 }

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -40,6 +40,7 @@ public class Configuration {
     private long inAppInterval;
     private boolean inAppEnableJavascript = false;
     private boolean inAppEnabled = false;
+    private boolean inAppManualTriggerEnabled = false;
 
     private boolean enableAutoAppOpen = false;
 
@@ -233,5 +234,13 @@ public class Configuration {
 
     public void setInAppEnabled(boolean inAppEnabled) {
         this.inAppEnabled = inAppEnabled;
+    }
+
+    public boolean isInAppManualTriggerEnabled() {
+        return inAppManualTriggerEnabled;
+    }
+
+    public void setInAppManualTriggerEnabled(boolean inAppManualTriggerEnabled) {
+        this.inAppManualTriggerEnabled = inAppManualTriggerEnabled;
     }
 }


### PR DESCRIPTION
This patch lets you enable a manual trigger for in-app. If you enable it, the api fetch and automatic in-app display will be stopped. The dev will have to explicitly call methods to get the api call and display to work.