### PR TITLE
Silent push to trigger in-app API call

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftConstants.java
@@ -127,4 +127,11 @@ public class BlueshiftConstants {
      * Bulk Event
      */
     public static final int BULK_EVENT_PAGE_SIZE = 100;
+
+    /*
+     * Silent push
+     */
+    public static final String SILENT_PUSH = "silent_push";
+    public static final String SILENT_PUSH_ACTION = "action";
+    public static final String ACTION_IN_APP_BACKGROUND_FETCH = "in_app_background_fetch";
 }

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -272,14 +272,18 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
     }
 
     protected void triggerInAppBackgroundFetch() {
-        final Configuration config = BlueshiftUtils.getConfiguration(this);
-        if (config != null && config.isInAppBackgroundFetchEnabled()) {
-            InAppManager.fetchInAppFromServer(this, new InAppApiCallback() {
-                @Override
-                public void onApiCallComplete() {
-                    InAppManager.invokeTriggerWithinSdk();
-                }
-            });
+        try {
+            final Configuration config = BlueshiftUtils.getConfiguration(this);
+            if (config != null && config.isInAppBackgroundFetchEnabled()) {
+                InAppManager.fetchInAppFromServer(this, new InAppApiCallback() {
+                    @Override
+                    public void onApiCallComplete() {
+                        InAppManager.invokeTriggerWithinSdk();
+                    }
+                });
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -15,8 +15,10 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.BuildConfig;
+import com.blueshift.inappmessage.InAppApiCallback;
 import com.blueshift.inappmessage.InAppManager;
 import com.blueshift.inappmessage.InAppMessage;
 import com.blueshift.inappmessage.InAppMessageStore;
@@ -170,6 +172,8 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
                 processPushNotification(data);
             } else if (isBlueshiftInAppMessage(data)) {
                 processInAppMessage(data);
+            } else if (isSilentPush(data)) {
+                processSilentPush(data);
             } else {
                 SdkLog.d(LOG_TAG, "Passing the push payload to host app via callback.");
 
@@ -187,6 +191,10 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
 
     private boolean isBlueshiftInAppMessage(Map<String, String> data) {
         return data != null && data.containsKey(InAppMessage.EXTRA_IN_APP);
+    }
+
+    public boolean isSilentPush(Map<String, String> data) {
+        return data != null && data.containsKey(BlueshiftConstants.SILENT_PUSH);
     }
 
     private void processPushNotification(Map<String, String> data) {
@@ -242,6 +250,36 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
             }
         } catch (Exception e) {
             BlueshiftLogger.e(LOG_TAG, e);
+        }
+    }
+
+    private void processSilentPush(Map<String, String> data) {
+        try {
+            if (data != null) {
+                String silentPushStr = data.get(BlueshiftConstants.SILENT_PUSH);
+                if (silentPushStr != null) {
+                    JSONObject silentPushJson = new JSONObject(silentPushStr);
+                    String action = silentPushJson.optString(BlueshiftConstants.SILENT_PUSH_ACTION);
+                    BlueshiftLogger.d(LOG_TAG, "Silent push with action '" + action + "' received.");
+                    if (BlueshiftConstants.ACTION_IN_APP_BACKGROUND_FETCH.equals(action)) {
+                        triggerInAppBackgroundFetch();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+    }
+
+    protected void triggerInAppBackgroundFetch() {
+        final Configuration config = BlueshiftUtils.getConfiguration(this);
+        if (config != null && config.isInAppBackgroundFetchEnabled()) {
+            InAppManager.fetchInAppFromServer(this, new InAppApiCallback() {
+                @Override
+                public void onApiCallComplete() {
+                    InAppManager.invokeTriggerWithinSdk();
+                }
+            });
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -41,6 +41,7 @@ public class Configuration {
     private boolean inAppEnableJavascript = false;
     private boolean inAppEnabled = false;
     private boolean inAppManualTriggerEnabled = false;
+    private boolean inAppBackgroundFetchEnabled = false;
 
     private boolean enableAutoAppOpen = false;
 
@@ -242,5 +243,13 @@ public class Configuration {
 
     public void setInAppManualTriggerEnabled(boolean inAppManualTriggerEnabled) {
         this.inAppManualTriggerEnabled = inAppManualTriggerEnabled;
+    }
+
+    public boolean isInAppBackgroundFetchEnabled() {
+        return inAppBackgroundFetchEnabled;
+    }
+
+    public void setInAppBackgroundFetchEnabled(boolean inAppBackgroundFetchEnabled) {
+        this.inAppBackgroundFetchEnabled = inAppBackgroundFetchEnabled;
     }
 }


### PR DESCRIPTION
This patch will enable the SDK to receive a silent push and trigger in-app api call based on the same. You should have the background fetch enabled (as given below) in the config before doing so.
```java
configuration.setInAppBackgroundFetchEnabled(true);
```