### PR TITLE
[MOBL-181] Option to switch device_id value

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -16,7 +16,7 @@ ext {
     siteUrl = 'https://getblueshift.com/'
     gitUrl = 'https://github.com/blueshift-labs/Blueshift-Android-SDK.git'
 
-    libraryVersion = '3.0.8'
+    libraryVersion = '3.0.9-beta01'
 
     developerId = 'rahulrvp'
     developerName = 'Rahul Raveendran V P'

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -67,6 +67,10 @@ public class Blueshift {
     private static Configuration mConfiguration;
     private static Blueshift instance = null;
 
+    public enum DeviceIdSource {
+        ADVERTISING_ID, INSTANCE_ID, GUID
+    }
+
     private Blueshift(Context context) {
         if (context != null) {
             mContext = context.getApplicationContext();

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -164,14 +164,14 @@ public class Blueshift {
     }
 
     /**
-     * Updates the sDeviceParams with android ad id
+     * Updates the sDeviceParams with device id
      *
-     * @param androidAdId android advertising id String
+     * @param deviceId device id as String
      */
-    private static void updateAndroidAdId(String androidAdId) {
+    private static void updateDeviceId(String deviceId) {
         synchronized (sDeviceParams) {
-            if (!TextUtils.isEmpty(androidAdId)) {
-                sDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, androidAdId);
+            if (!TextUtils.isEmpty(deviceId)) {
+                sDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, deviceId);
             }
         }
     }
@@ -247,13 +247,9 @@ public class Blueshift {
             if (simOperatorName != null) {
                 sDeviceParams.put(BlueshiftConstants.KEY_NETWORK_CARRIER, simOperatorName);
             }
-
-            String deviceId = DeviceUtils.getDeviceId(mContext);
-            if (TextUtils.isEmpty(deviceId)) {
-                BlueshiftLogger.e(LOG_TAG, "device_id is null/empty");
-            }
-            sDeviceParams.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, deviceId);
         }
+
+        new UpdateDeviceIdTask().execute(mContext);
 
         if (mConfiguration != null && mConfiguration.isPushEnabled()) {
             updateFCMToken();
@@ -1297,26 +1293,21 @@ public class Blueshift {
     }
 
     /**
-     * Updates the sDeviceParams with advertising ID
+     * Updates the sDeviceParams with device_id
      */
-    private class FetchAndUpdateAdIdTask extends AsyncTask<Void, Void, String> {
+    private static class UpdateDeviceIdTask extends AsyncTask<Context, Void, String> {
 
         @Override
-        protected void onPreExecute() {
-            SdkLog.i(LOG_TAG, "Trying to fetch AdvertisingId");
-        }
-
-        @Override
-        protected String doInBackground(Void... params) {
-            return DeviceUtils.getDeviceId(mContext);
+        protected String doInBackground(Context... contexts) {
+            return contexts != null && contexts.length > 0 ? DeviceUtils.getDeviceId(contexts[0]) : null;
         }
 
         @Override
         protected void onPostExecute(String adId) {
-            if (!TextUtils.isEmpty(adId)) {
-                updateAndroidAdId(adId);
+            if (TextUtils.isEmpty(adId)) {
+                BlueshiftLogger.e(LOG_TAG, "Could not get a valid device_id");
             } else {
-                SdkLog.w(LOG_TAG, "Could not fetch AdvertisingId");
+                updateDeviceId(adId);
             }
         }
     }

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -44,6 +44,7 @@ public class Configuration {
     private boolean inAppBackgroundFetchEnabled = false;
 
     private boolean enableAutoAppOpen = false;
+    private boolean shouldUseAdvertisingIdAsDeviceId = true;
 
     public Configuration() {
         inAppInterval = InAppConstants.IN_APP_INTERVAL;
@@ -251,5 +252,13 @@ public class Configuration {
 
     public void setInAppBackgroundFetchEnabled(boolean inAppBackgroundFetchEnabled) {
         this.inAppBackgroundFetchEnabled = inAppBackgroundFetchEnabled;
+    }
+
+    public boolean shouldUseAdvertisingIdAsDeviceId() {
+        return shouldUseAdvertisingIdAsDeviceId;
+    }
+
+    public void setShouldUseAdvertisingIdAsDeviceId(boolean useAdvertisingIdAsDeviceId) {
+        this.shouldUseAdvertisingIdAsDeviceId = useAdvertisingIdAsDeviceId;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -2,6 +2,7 @@ package com.blueshift.model;
 
 import android.app.AlarmManager;
 
+import com.blueshift.Blueshift;
 import com.blueshift.inappmessage.InAppConstants;
 
 /**
@@ -44,9 +45,11 @@ public class Configuration {
     private boolean inAppBackgroundFetchEnabled = false;
 
     private boolean enableAutoAppOpen = false;
-    private boolean shouldUseAdvertisingIdAsDeviceId = true;
+
+    private Blueshift.DeviceIdSource deviceIdSource;
 
     public Configuration() {
+        deviceIdSource = Blueshift.DeviceIdSource.ADVERTISING_ID;
         inAppInterval = InAppConstants.IN_APP_INTERVAL;
         batchInterval = AlarmManager.INTERVAL_HALF_HOUR;
         networkChangeListenerJobId = 901;
@@ -254,11 +257,11 @@ public class Configuration {
         this.inAppBackgroundFetchEnabled = inAppBackgroundFetchEnabled;
     }
 
-    public boolean shouldUseAdvertisingIdAsDeviceId() {
-        return shouldUseAdvertisingIdAsDeviceId;
+    public Blueshift.DeviceIdSource getDeviceIdSource() {
+        return deviceIdSource;
     }
 
-    public void setShouldUseAdvertisingIdAsDeviceId(boolean useAdvertisingIdAsDeviceId) {
-        this.shouldUseAdvertisingIdAsDeviceId = useAdvertisingIdAsDeviceId;
+    public void setDeviceIdSource(Blueshift.DeviceIdSource deviceIdSource) {
+        this.deviceIdSource = deviceIdSource;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -15,6 +15,7 @@ import com.blueshift.model.Configuration;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.firebase.iid.FirebaseInstanceId;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -67,10 +68,20 @@ public class DeviceUtils {
         String deviceId;
 
         Configuration configuration = BlueshiftUtils.getConfiguration(context);
-        if (configuration != null && configuration.shouldUseAdvertisingIdAsDeviceId()) {
-            deviceId = getAdvertisingId(context);
+        if (configuration != null && configuration.getDeviceIdSource() != null) {
+            switch (configuration.getDeviceIdSource()) {
+                case INSTANCE_ID:
+                    deviceId = FirebaseInstanceId.getInstance().getId();
+                    break;
+                case GUID:
+                    deviceId = BlueShiftPreference.getDeviceID(context);
+                    break;
+                default:
+                    // ADVERTISING_ID & Others
+                    deviceId = getAdvertisingId(context);
+            }
         } else {
-            deviceId = BlueShiftPreference.getDeviceID(context);
+            deviceId = getAdvertisingId(context);
         }
 
         return deviceId;


### PR DESCRIPTION
This change will let the developer decide what should be used as device_id. By default, the device_id would be Ad ID. Dev can change it to a GUID by setting a flag in config.