### PR TITLE
Use implemention instead of compile

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -58,12 +58,12 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
     // for JSON parsing
-    compile 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.2'
     // for FCM
-    compile 'com.google.firebase:firebase-core:16.0.6'
-    compile 'com.google.firebase:firebase-messaging:17.3.4'
+    implementation 'com.google.firebase:firebase-core:16.0.6'
+    implementation 'com.google.firebase:firebase-messaging:17.3.4'
 
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Using implementation exposes the libraries to the apps using the SDK. This was discovered due to firebase-core conflicting with the newer firebase-analytics replacement which are not compatible.