### PR TITLE
[MOBL-234] Remove AsyncTask from ScheduledPushReceiver

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueshiftExecutor.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftExecutor.java
@@ -13,11 +13,13 @@ public class BlueshiftExecutor {
     private final Executor uiExecutor;
     private final Executor diskExecutor;
     private final Executor networkExecutor;
+    private final Executor workerExecutor;
 
-    private BlueshiftExecutor(Executor uiExecutor, Executor diskExecutor, Executor networkExecutor) {
+    private BlueshiftExecutor(Executor uiExecutor, Executor diskExecutor, Executor networkExecutor, Executor workerExecutor) {
         this.uiExecutor = uiExecutor;
         this.diskExecutor = diskExecutor;
         this.networkExecutor = networkExecutor;
+        this.workerExecutor = workerExecutor;
     }
 
     public static BlueshiftExecutor getInstance() {
@@ -25,8 +27,8 @@ public class BlueshiftExecutor {
             sInstance = new BlueshiftExecutor(
                     new UIExecutor(),
                     Executors.newSingleThreadExecutor(),
-                    Executors.newFixedThreadPool(3)
-            );
+                    Executors.newFixedThreadPool(3),
+                    Executors.newFixedThreadPool(2));
         }
 
         return sInstance;
@@ -47,6 +49,12 @@ public class BlueshiftExecutor {
     public void runOnDiskIOThread(Runnable runnable) {
         if (diskExecutor != null) {
             diskExecutor.execute(runnable);
+        }
+    }
+
+    public void runOnWorkerThread(Runnable runnable) {
+        if (workerExecutor != null) {
+            workerExecutor.execute(runnable);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/ScheduledPushReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/ScheduledPushReceiver.java
@@ -3,10 +3,11 @@ package com.blueshift.rich_push;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.blueshift.BlueshiftExecutor;
+import com.blueshift.BlueshiftLogger;
 import com.google.gson.Gson;
 
 import java.text.SimpleDateFormat;
@@ -38,7 +39,7 @@ public class ScheduledPushReceiver extends BroadcastReceiver {
                 }
 
                 if (message != null) {
-                    processPayload(context, message);
+                    processPayload(context.getApplicationContext(), message);
                 } else {
                     Log.e(LOG_TAG, "NULL message payload received. " + messageJSON);
                 }
@@ -51,17 +52,20 @@ public class ScheduledPushReceiver extends BroadcastReceiver {
     }
 
     private void processPayload(final Context context, final Message message) {
-        new AsyncTask<Void, Void, Void>() {
-            @Override
-            protected Void doInBackground(Void... params) {
-                try {
-                    NotificationFactory
-                            .handleMessage(context.getApplicationContext(), message);
-                } catch (Exception e) {
-                    Log.e(LOG_TAG, e.getMessage() != null ? e.getMessage() : "Unknown error!");
+        BlueshiftExecutor.getInstance().runOnWorkerThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            NotificationFactory.handleMessage(
+                                    context,
+                                    message
+                            );
+                        } catch (Exception e) {
+                            BlueshiftLogger.e(LOG_TAG, e);
+                        }
+                    }
                 }
-                return null;
-            }
-        }.execute();
+        );
     }
 }


### PR DESCRIPTION
Added generic executor with two threads for common usage
Replaces async task from scheduled push receiver