### PR TITLE
[MOBL-256] Combo device ids

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -67,7 +67,7 @@ public class Blueshift {
     private static Blueshift instance = null;
 
     public enum DeviceIdSource {
-        ADVERTISING_ID, INSTANCE_ID, GUID
+        ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME
     }
 
     private Blueshift(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -75,6 +75,14 @@ public class DeviceUtils {
                 case GUID:
                     deviceId = BlueShiftPreference.getDeviceID(context);
                     break;
+                case ADVERTISING_ID_PKG_NAME:
+                    deviceId = getAdvertisingId(context);
+                    deviceId += (":" + context.getPackageName());
+                    break;
+                case INSTANCE_ID_PKG_NAME:
+                    deviceId = FirebaseInstanceId.getInstance().getId();
+                    deviceId += (":" + context.getPackageName());
+                    break;
                 default:
                     // ADVERTISING_ID & Others
                     deviceId = getAdvertisingId(context);
@@ -82,6 +90,8 @@ public class DeviceUtils {
         } else {
             deviceId = getAdvertisingId(context);
         }
+
+        BlueshiftLogger.d(LOG_TAG, "{ \"device_id\" : \"" + deviceId + "\" }");
 
         return deviceId;
     }

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -64,7 +64,7 @@ public class DeviceUtils {
      */
     @WorkerThread
     public static String getDeviceId(Context context) {
-        String deviceId;
+        String deviceId = null;
 
         Configuration configuration = BlueshiftUtils.getConfiguration(context);
         if (configuration != null && configuration.getDeviceIdSource() != null) {
@@ -76,12 +76,22 @@ public class DeviceUtils {
                     deviceId = BlueShiftPreference.getDeviceID(context);
                     break;
                 case ADVERTISING_ID_PKG_NAME:
-                    deviceId = getAdvertisingId(context);
-                    deviceId += (":" + context.getPackageName());
+                    try {
+                        deviceId = getAdvertisingId(context);
+                        deviceId += (":" + context.getPackageName());
+                    } catch (Exception e) {
+                        BlueshiftLogger.e(LOG_TAG, "Could not build \"advertising id - pkg name\" combo.");
+                        BlueshiftLogger.e(LOG_TAG, e);
+                    }
                     break;
                 case INSTANCE_ID_PKG_NAME:
-                    deviceId = FirebaseInstanceId.getInstance().getId();
-                    deviceId += (":" + context.getPackageName());
+                    try {
+                        deviceId = FirebaseInstanceId.getInstance().getId();
+                        deviceId += (":" + context.getPackageName());
+                    } catch (Exception e) {
+                        BlueshiftLogger.e(LOG_TAG, "Could not build \"instance id - pkg name\" combo.");
+                        BlueshiftLogger.e(LOG_TAG, e);
+                    }
                     break;
                 default:
                     // ADVERTISING_ID & Others
@@ -90,8 +100,6 @@ public class DeviceUtils {
         } else {
             deviceId = getAdvertisingId(context);
         }
-
-        BlueshiftLogger.d(LOG_TAG, "{ \"device_id\" : \"" + deviceId + "\" }");
 
         return deviceId;
     }


### PR DESCRIPTION
This change adds two more device_id sources to the configuration.
1. Advertising Id and package name combo separated with a colon (ad_id:pkg_name)
2. Instance Id and package name combo separated with a colon (instance_id:pkg_name)