### PR TITLE
[MOBL-282] Accepting non-string params from mp push callback

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -182,8 +182,8 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
                 if (bundle != null) {
                     Map<String, String> map = new HashMap<>();
                     for (String key : bundle.keySet()) {
-                        String val = bundle.getString(key);
-                        if (val != null) map.put(key, val);
+                        Object val = bundle.get(key);
+                        if (val != null) map.put(key, String.valueOf(val));
                     }
 
                     BlueshiftMessagingService service = new BlueshiftMessagingService();


### PR DESCRIPTION
The `google.ttl` and `google.send_time` was added in push Intent as extra when attempted a silent push. This was crashing when tried to cast to `String`. This issue is fixed in this patch.