### PR TITLE
[MOBL-285] bugfix: sending bulkevents inside "events" as array

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/httpmanager/HTTPManager.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/HTTPManager.java
@@ -165,7 +165,6 @@ public class HTTPManager {
 
     private Response getResponse() {
         Response response = new Response();
-        BlueshiftLogger.d(LOG_TAG, mUrlConnection.getRequestMethod() + " " + mUrl);
 
         try {
             response.setStatusCode(mUrlConnection.getResponseCode());

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/Request.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/Request.java
@@ -1,5 +1,6 @@
 package com.blueshift.httpmanager;
 
+import com.blueshift.BlueshiftLogger;
 import com.google.gson.Gson;
 
 import java.io.Serializable;
@@ -27,6 +28,17 @@ public class Request implements Serializable {
     public Request() {
         pendingRetryCount = 1;
         nextRetryTime = 0;
+    }
+
+    public void log(String tag, Response response) {
+        String builder = "{" +
+                "\"url\":\"" + url + "\"," +
+                "\"method\":\"" + method + "\"," +
+                "\"params\":" + paramJson + "," +
+                "\"status\":" + (response != null ? response.getStatusCode() : "\"NA\"") + "," +
+                "\"response\":" + (response != null ? response.getResponseBody() : "\"NA\"") +
+                "}";
+        BlueshiftLogger.d(tag, builder);
     }
 
     public HashMap<String, String> getUrlParams() {

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -243,7 +243,6 @@ class RequestDispatcher {
             switch (mRequest.getMethod()) {
                 case POST:
                     String json = mRequest.getParamJson();
-                    BlueshiftLogger.d(LOG_TAG, "POST: Request params: " + json);
 
                     response = httpManager.post(json);
                     String eventName = getEventName(json);
@@ -256,14 +255,15 @@ class RequestDispatcher {
                 case GET:
                     response = httpManager.get();
 
-                    BlueshiftLogger.d(LOG_TAG, "Method: GET, " +
-                            "URL: " + mRequest.getUrl() + ", " +
-                            "Status: " + getStatusFromResponse(response));
 
                     break;
 
                 default:
                     BlueshiftLogger.e(LOG_TAG, "Unknown method" + mRequest.getMethod());
+            }
+
+            if (response != null && mRequest != null) {
+                mRequest.log(LOG_TAG, response);
             }
         }
 

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -172,14 +172,16 @@ class RequestDispatcher {
                     if (!TextUtils.isEmpty(payload)) {
                         try {
                             JSONObject payloadJson = new JSONObject(payload);
-                            if (payloadJson.has("events")) {
-                                JSONArray eventArray = payloadJson.getJSONArray("events");
+                            String eventsKey = "events";
+                            if (payloadJson.has(eventsKey)) {
+                                JSONArray eventArray = payloadJson.getJSONArray(eventsKey);
                                 for (int index = 0; index < eventArray.length(); index++) {
                                     JSONObject event = eventArray.getJSONObject(index);
                                     event.put(BlueshiftConstants.KEY_DEVICE_TOKEN, token);
                                     eventArray.put(index, event);
                                 }
-                                mRequest.setParamJson(eventArray.toString());
+                                payloadJson.putOpt(eventsKey, eventArray);
+                                mRequest.setParamJson(payloadJson.toString());
                             }
                         } catch (Exception e) {
                             BlueshiftLogger.e(LOG_TAG, e);


### PR DESCRIPTION
- Events sent to bulkevents API will be added inside the "events" key. { "events" : [ <events array> ] }
- Log the API call details and remove duplicate logs