### PR TITLE
[MOBL-296] dismiss in-app on outside touch made configurable

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppConstants.java
@@ -30,6 +30,7 @@ public class InAppConstants {
     public static final String TEMPLATE_STYLE_DARK = "template_style_dark";
 
     // payload: level-2 keys
+    public static final String CANCEL_ON_TOUCH_OUTSIDE = "cancel_on_touch_outside";
     public static final String WIDTH = "width";
     public static final String BACKGROUND_DIM_AMOUNT = "background_dim_amount";
     public static final String HEIGHT = "height";

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -565,6 +565,10 @@ public class InAppManager {
                 AlertDialog.Builder builder = new AlertDialog.Builder(context, theme);
                 builder.setView(content);
                 mDialog = builder.create();
+
+                boolean cancelOnTouchOutside = InAppUtils.shouldCancelOnTouchOutside(context, inAppMessage);
+                mDialog.setCanceledOnTouchOutside(cancelOnTouchOutside);
+
                 mDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
                     @Override
                     public void onDismiss(DialogInterface dialogInterface) {

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -116,6 +116,18 @@ public class InAppUtils {
         return fallback;
     }
 
+    public static boolean getBooleanFromJSONObject(JSONObject jsonObject, String key, boolean fallback) {
+        try {
+            if (jsonObject != null && !TextUtils.isEmpty(key)) {
+                return jsonObject.optBoolean(key, fallback);
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+
+        return fallback;
+    }
+
     public static Rect getRectFromJSONObject(JSONObject jsonObject, String key) {
         try {
             if (jsonObject != null && !TextUtils.isEmpty(key)) {
@@ -283,6 +295,19 @@ public class InAppUtils {
         return fallback;
     }
 
+    public static boolean getTemplateBoolean(Context context, InAppMessage inAppMessage, String contentName, boolean fallback) {
+        try {
+            if (inAppMessage != null) {
+                JSONObject templateStyle = getTemplateStyle(context, inAppMessage, contentName);
+                return getBooleanFromJSONObject(templateStyle, contentName, fallback);
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+
+        return fallback;
+    }
+
     public static double getTemplateBackgroundDimAmount(Context context, InAppMessage inAppMessage, double fallback) {
         return getTemplateDouble(context, inAppMessage, InAppConstants.BACKGROUND_DIM_AMOUNT, fallback);
     }
@@ -373,6 +398,21 @@ public class InAppUtils {
                 JSONArray actions = inAppMessage.getActionsJSONArray();
                 boolean hasNoActions = actions == null || actions.length() == 0;
                 result = isModal(inAppMessage) && hasNoActions;
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+
+        return result;
+    }
+
+    public static boolean shouldCancelOnTouchOutside(Context context, InAppMessage inAppMessage) {
+        boolean result = false;
+
+        try {
+            if (inAppMessage != null) {
+                boolean shouldCancel = isSlideIn(inAppMessage); // slide in is by default cancellable on touch outside
+                result = getTemplateBoolean(context, inAppMessage, InAppConstants.CANCEL_ON_TOUCH_OUTSIDE, shouldCancel);
             }
         } catch (Exception e) {
             BlueshiftLogger.e(LOG_TAG, e);


### PR DESCRIPTION
- slide in is cancellable by default when touching outside
- other templates are non-cancellable on touching outside
- the above behavior is configurable using payload