### PR TITLE
[MOBL-343] custom device id

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -70,7 +70,7 @@ public class Blueshift {
     private static Blueshift instance = null;
 
     public enum DeviceIdSource {
-        ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME
+        ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME, CUSTOM
     }
 
     private Blueshift(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -50,6 +50,7 @@ public class Configuration {
     private boolean enableAutoAppOpen;
 
     private Blueshift.DeviceIdSource deviceIdSource;
+    private String customDeviceId;
 
     public Configuration() {
         // In-App Messaging
@@ -285,13 +286,17 @@ public class Configuration {
         this.deviceIdSource = deviceIdSource;
     }
 
+    public String getCustomDeviceId() {
+        return customDeviceId;
+    }
+
     public void setCustomDeviceId(String deviceId) {
         if (this.deviceIdSource == Blueshift.DeviceIdSource.CUSTOM) {
             if (TextUtils.isEmpty(deviceId)) {
                 BlueshiftLogger.e(null, "No valid device_id is provided by the host app.");
             } else {
                 BlueshiftLogger.d(null, "Custom device id available: " + deviceId);
-                DeviceUtils.setCustomDeviceId(deviceId);
+                this.customDeviceId = deviceId;
             }
         } else {
             BlueshiftLogger.e(null, "Can not use custom device id without setting the deviceIdSource as Blueshift.DeviceIdSource.CUSTOM");

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -1,9 +1,12 @@
 package com.blueshift.model;
 
 import android.app.AlarmManager;
+import android.text.TextUtils;
 
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftLogger;
 import com.blueshift.inappmessage.InAppConstants;
+import com.blueshift.util.DeviceUtils;
 
 /**
  * @author Rahul Raveendran V P
@@ -280,5 +283,18 @@ public class Configuration {
 
     public void setDeviceIdSource(Blueshift.DeviceIdSource deviceIdSource) {
         this.deviceIdSource = deviceIdSource;
+    }
+
+    public void setCustomDeviceId(String deviceId) {
+        if (this.deviceIdSource == Blueshift.DeviceIdSource.CUSTOM) {
+            if (TextUtils.isEmpty(deviceId)) {
+                BlueshiftLogger.e(null, "No valid device_id is provided by the host app.");
+            } else {
+                BlueshiftLogger.d(null, "Custom device id available: " + deviceId);
+                DeviceUtils.setCustomDeviceId(deviceId);
+            }
+        } else {
+            BlueshiftLogger.e(null, "Can not use custom device id without setting the deviceIdSource as Blueshift.DeviceIdSource.CUSTOM");
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -32,12 +32,6 @@ import java.util.Enumeration;
 public class DeviceUtils {
     private static final String LOG_TAG = DeviceUtils.class.getSimpleName();
 
-    private static String customDeviceId;
-
-    public static void setCustomDeviceId(String deviceId) {
-        customDeviceId = deviceId;
-    }
-
     public static String getSIMOperatorName(Context context) {
         TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
         if (telephonyManager != null) {
@@ -101,10 +95,10 @@ public class DeviceUtils {
                     }
                     break;
                 case CUSTOM:
-                    if (TextUtils.isEmpty(customDeviceId)) {
+                    deviceId = configuration.getCustomDeviceId();
+                    if (TextUtils.isEmpty(deviceId)) {
                         BlueshiftLogger.e(LOG_TAG, "Custom device id is not provided!");
                     }
-                    deviceId = customDeviceId;
                     break;
                 default:
                     // ADVERTISING_ID & Others

--- a/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/DeviceUtils.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.WorkerThread;
 import android.telephony.TelephonyManager;
+import android.text.TextUtils;
 
 import com.blueshift.BlueShiftPreference;
 import com.blueshift.BlueshiftLogger;
@@ -30,6 +31,12 @@ import java.util.Enumeration;
  */
 public class DeviceUtils {
     private static final String LOG_TAG = DeviceUtils.class.getSimpleName();
+
+    private static String customDeviceId;
+
+    public static void setCustomDeviceId(String deviceId) {
+        customDeviceId = deviceId;
+    }
 
     public static String getSIMOperatorName(Context context) {
         TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
@@ -92,6 +99,12 @@ public class DeviceUtils {
                         BlueshiftLogger.e(LOG_TAG, "Could not build \"instance id - pkg name\" combo.");
                         BlueshiftLogger.e(LOG_TAG, e);
                     }
+                    break;
+                case CUSTOM:
+                    if (TextUtils.isEmpty(customDeviceId)) {
+                        BlueshiftLogger.e(LOG_TAG, "Custom device id is not provided!");
+                    }
+                    deviceId = customDeviceId;
                     break;
                 default:
                     // ADVERTISING_ID & Others


### PR DESCRIPTION
This change will allow the host app to provide a string to the SDK to use as `device_id`.
The device_id should be in an acceptable format. It should not contain special characters and whitespace in it.