### PR TITLE
[MOBL-382] optimise jobscheduler and alarm managers 

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/batch/BulkEventJobService.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/BulkEventJobService.java
@@ -2,40 +2,45 @@ package com.blueshift.batch;
 
 import android.app.job.JobParameters;
 import android.app.job.JobService;
-import android.content.Context;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 
-import com.blueshift.BlueshiftExecutor;
 import com.blueshift.BlueshiftLogger;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class BulkEventJobService extends JobService {
-
-    private static final String LOG_TAG = BulkEventJobService.class.getSimpleName();
+    private static final String TAG = "BulkEventJobService";
 
     @Override
-    public boolean onStartJob(final JobParameters params) {
-        final Context context = this;
+    public boolean onStartJob(JobParameters jobParameters) {
+        BlueshiftLogger.d(TAG, "Job started.");
+        doBackgroundWork(jobParameters);
 
-        BlueshiftExecutor.getInstance().runOnDiskIOThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        BlueshiftLogger.d(LOG_TAG, "Enqueue bulk events started.");
-                        BulkEventManager.enqueueBulkEvents(context);
-                        BlueshiftLogger.d(LOG_TAG, "Enqueue bulk events completed.");
+        // The job should continue running as the enqueue operation may take a while
+        // we have the jobFinished method called once the task is complete.
+        return true;
+    }
 
-                        jobFinished(params, true);
-                    }
-                }
-        );
+    private void doBackgroundWork(final JobParameters jobParameters) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                BulkEventManager.enqueueBulkEvents(getApplicationContext());
 
-        return false;
+                // this is a periodic job, we don't need the job scheduler to
+                // reschedule this with available backoff policy. hence passing
+                // false as 2nd argument.
+                jobFinished(jobParameters, false);
+
+                BlueshiftLogger.d(TAG, "Job completed.");
+            }
+        }).start();
     }
 
     @Override
     public boolean onStopJob(JobParameters jobParameters) {
+        BlueshiftLogger.d(TAG, "Job cancel requested.");
+
         return false;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -45,8 +45,6 @@ public class BulkEventManager {
     private static void scheduleBulkEventDispatchWithJobScheduler(Context context) {
         try {
             if (context != null) {
-                long fiveMinutes = 1000 * 60 * 5;
-
                 Configuration config = BlueshiftUtils.getConfiguration(context);
                 if (config != null) {
                     int jobId = config.getBulkEventsJobId();
@@ -57,7 +55,6 @@ public class BulkEventManager {
                     JobInfo.Builder builder = new JobInfo.Builder(jobId, componentName);
 
                     builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
-                    builder.setBackoffCriteria(fiveMinutes, JobInfo.BACKOFF_POLICY_EXPONENTIAL);
                     builder.setPeriodic(config.getBatchInterval()); // 30 min batch interval by default
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
@@ -5,6 +5,7 @@ import android.app.job.JobService;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 
+import com.blueshift.BlueshiftLogger;
 import com.blueshift.request_queue.RequestQueue;
 
 
@@ -17,18 +18,39 @@ import com.blueshift.request_queue.RequestQueue;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class RequestQueueJobService extends JobService {
+    private static final String TAG = "RequestQueueJobService";
 
     @Override
     public boolean onStartJob(JobParameters jobParameters) {
-        RequestQueue.getInstance().syncInBackground(this);
-        // this method needs to be called to release the wakelock
-        jobFinished(jobParameters, false);
+        BlueshiftLogger.d(TAG, "Job started.");
+        doBackgroundWork(jobParameters);
 
+        // The job should continue running as the enqueue operation may take a while
+        // we have the jobFinished method called once the task is complete.
         return true;
     }
 
+    private void doBackgroundWork(final JobParameters jobParameters) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                RequestQueue.getInstance().sync(getApplicationContext());
+
+                // this is a periodic job, we don't need the job scheduler to
+                // reschedule this with available backoff policy. hence passing
+                // false as 2nd argument.
+                jobFinished(jobParameters, false);
+
+                BlueshiftLogger.d(TAG, "Job completed.");
+            }
+        }).start();
+    }
+
+
     @Override
     public boolean onStopJob(JobParameters jobParameters) {
+        BlueshiftLogger.d(TAG, "Job cancel requested.");
+
         return false;
     }
 

--- a/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
+++ b/android-sdk/src/main/java/com/blueshift/httpmanager/request_queue/RequestQueueJobService.java
@@ -46,12 +46,10 @@ public class RequestQueueJobService extends JobService {
         }).start();
     }
 
-
     @Override
     public boolean onStopJob(JobParameters jobParameters) {
         BlueshiftLogger.d(TAG, "Job cancel requested.");
 
         return false;
     }
-
 }

--- a/android-sdk/src/main/java/com/blueshift/receiver/NetworkChangeListener.java
+++ b/android-sdk/src/main/java/com/blueshift/receiver/NetworkChangeListener.java
@@ -21,10 +21,23 @@ public class NetworkChangeListener extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (context != null && intent != null
-                && "android.net.conn.CONNECTIVITY_CHANGE".equals(intent.getAction())) {
-            // call the db sync task to send events to server
-            RequestQueue.getInstance().syncInBackground(context);
+        String action = "android.net.conn.CONNECTIVITY_CHANGE";
+        if (context != null && intent != null && action.equals(intent.getAction())) {
+            doBackgroundWork(context);
+        }
+    }
+
+    private void doBackgroundWork(Context context) {
+        final Context appContext = context != null ? context.getApplicationContext() : null;
+        if (appContext != null) {
+            new Thread(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            RequestQueue.getInstance().sync(appContext);
+                        }
+                    }
+            ).start();
         }
     }
 }


### PR DESCRIPTION
ANR can happen if we use the broadcast/job services context as is or if we do long-running tasks with it. This patch will avoid that by using app context and worker threads.