### PR TITLE
[MOBL-398] Fix serializable issue in samsung

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
@@ -43,7 +43,7 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
 
     protected void processAction(String action, Bundle extraBundle) {
         if (extraBundle != null) {
-            Message message = (Message) extraBundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+            Message message = Message.parseBundle(extraBundle);
             if (message != null) {
                 try {
                     // mark 'click'

--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsService.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsService.java
@@ -61,7 +61,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
                     BlueshiftLogger.d(LOG_TAG, "No bundle data available with the broadcast.");
                 }
 
-                Message message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+                Message message = Message.parseIntent(intent);
 
                 // remove cached images(if any) for this notification
                 NotificationUtils.removeCachedCarouselImages(this, message);
@@ -83,7 +83,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayProductPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getProductPage() != null) {
@@ -110,7 +110,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void addToCart(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getCartPage() != null) {
@@ -137,7 +137,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayCartPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getCartPage() != null) {
@@ -159,7 +159,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayOfferDisplayPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getOfferDisplayPage() != null) {
@@ -181,7 +181,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void openApp(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             PackageManager packageManager = context.getPackageManager();
             Intent launcherIntent = packageManager.getLaunchIntentForPackage(context.getPackageName());

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CarouselElement.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CarouselElement.java
@@ -1,6 +1,11 @@
 package com.blueshift.rich_push;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.text.TextUtils;
+
+import com.blueshift.BlueshiftLogger;
+import com.google.gson.Gson;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -9,10 +14,12 @@ import java.util.HashMap;
  * This model represents the carousel element in carousel type notifications.
  *
  * @author Rahul Raveendran V P
- *         Created on 16/9/16 @ 3:03 PM
- *         https://github.com/rahulrvp
+ * Created on 16/9/16 @ 3:03 PM
+ * https://github.com/rahulrvp
  */
 public class CarouselElement implements Serializable {
+    private static final String TAG = "CarouselElement";
+
     /**
      * CarouselElementText to be shown on the carousel element
      */
@@ -86,5 +93,36 @@ public class CarouselElement implements Serializable {
 
     public CarouselElementText getContentSubtext() {
         return content_subtext;
+    }
+
+    public static CarouselElement parseIntent(Intent intent) {
+        if (intent != null) {
+            return parseBundle(intent.getExtras());
+        }
+
+        return null;
+    }
+
+    public static CarouselElement parseBundle(Bundle bundle) {
+        if (bundle != null) {
+            String json = bundle.getString(RichPushConstants.EXTRA_CAROUSEL_ELEMENT);
+            return fromJson(json);
+        }
+
+        return null;
+    }
+
+    public static CarouselElement fromJson(String json) {
+        try {
+            return new Gson().fromJson(json, CarouselElement.class);
+        } catch (Exception e) {
+            BlueshiftLogger.e(TAG, e);
+        }
+
+        return null;
+    }
+
+    public String toJson() {
+        return new Gson().toJson(this);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -694,13 +694,17 @@ class CustomNotificationFactory {
 
         Bundle bundle = new Bundle();
         bundle.putInt(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationId);
-        bundle.putSerializable(RichPushConstants.EXTRA_MESSAGE, message);
-        bundle.putSerializable(RichPushConstants.EXTRA_CAROUSEL_ELEMENT, element);
+        if (message != null) {
+            bundle.putString(RichPushConstants.EXTRA_MESSAGE, message.toJson());
+        }
+        if (element != null) {
+            bundle.putString(RichPushConstants.EXTRA_CAROUSEL_ELEMENT, element.toJson());
 
-        if (element.isDeepLinkingEnabled()) {
-            bundle.putString(RichPushConstants.EXTRA_DEEP_LINK_URL, element.getDeepLinkUrl());
-        } else {
-            action = RichPushConstants.buildAction(context, element.getAction());
+            if (element.isDeepLinkingEnabled()) {
+                bundle.putString(RichPushConstants.EXTRA_DEEP_LINK_URL, element.getDeepLinkUrl());
+            } else {
+                action = RichPushConstants.buildAction(context, element.getAction());
+            }
         }
 
         // get the activity to handle clicks (user defined or sdk defined

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -1,6 +1,11 @@
 package com.blueshift.rich_push;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.text.TextUtils;
+
+import com.blueshift.BlueshiftLogger;
+import com.google.gson.Gson;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -12,6 +17,8 @@ import java.util.List;
  *         https://github.com/rahulrvp
  */
 public class Message implements Serializable {
+    private static final String TAG = "Message";
+
     public static final String EXTRA_MESSAGE = "message";
     public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
     public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
@@ -379,5 +386,36 @@ public class Message implements Serializable {
 
     public String getNotificationChannelDescription() {
         return notification_channel_description;
+    }
+
+    public static Message parseIntent(Intent intent) {
+        if (intent != null) {
+            return parseBundle(intent.getExtras());
+        }
+
+        return null;
+    }
+
+    public static Message parseBundle(Bundle bundle) {
+        if (bundle != null) {
+            String json = bundle.getString(RichPushConstants.EXTRA_MESSAGE);
+            return fromJson(json);
+        }
+
+        return null;
+    }
+
+    public static Message fromJson(String json) {
+        try {
+            return new Gson().fromJson(json, Message.class);
+        } catch (Exception e) {
+            BlueshiftLogger.e(TAG, e);
+        }
+
+        return null;
+    }
+
+    public String toJson() {
+        return new Gson().toJson(this);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -33,7 +33,7 @@ public class NotificationActivity extends AppCompatActivity {
         mContext = this;
 
         try {
-            mMessage = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+            mMessage = Message.parseIntent(getIntent());
         } catch (Exception ignore) {
         }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -172,9 +172,6 @@ public class NotificationFactory {
                     }
                 }
 
-                // pending intent that opens the app using MAIN activity.
-                PendingIntent openAppPendingIntent = getOpenAppPendingIntent(context, message, notificationId);
-
                 switch (message.getCategory()) {
                     case Buy:
                         PendingIntent viewPendingIntent = getViewActionPendingIntent(context, message, notificationId);
@@ -183,7 +180,8 @@ public class NotificationFactory {
                         PendingIntent buyPendingIntent = getBuyActionPendingIntent(context, message, notificationId);
                         builder.addAction(0, "Buy", buyPendingIntent);
 
-                        builder.setContentIntent(openAppPendingIntent);
+                        PendingIntent contentIntentForBuy = getOpenAppPendingIntent(context, message, notificationId);
+                        builder.setContentIntent(contentIntentForBuy);
 
                         break;
 
@@ -191,7 +189,8 @@ public class NotificationFactory {
                         PendingIntent openCartPendingIntent = getOpenCartPendingIntent(context, message, notificationId);
                         builder.addAction(0, "Open Cart", openCartPendingIntent);
 
-                        builder.setContentIntent(openAppPendingIntent);
+                        PendingIntent contentIntentForViewCart = getOpenAppPendingIntent(context, message, notificationId);
+                        builder.setContentIntent(contentIntentForViewCart);
 
                         break;
 
@@ -205,7 +204,8 @@ public class NotificationFactory {
                         /*
                          * Default action is to open app and send all details as extra inside intent
                          */
-                        builder.setContentIntent(openAppPendingIntent);
+                        PendingIntent contentIntentForOpenApp = getOpenAppPendingIntent(context, message, notificationId);
+                        builder.setContentIntent(contentIntentForOpenApp);
                 }
             }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -398,7 +398,7 @@ public class NotificationFactory {
         bundle.putInt(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationId);
 
         if (message != null) {
-            bundle.putSerializable(RichPushConstants.EXTRA_MESSAGE, message);
+            bundle.putString(RichPushConstants.EXTRA_MESSAGE, message.toJson());
 
             if (message.isDeepLinkingEnabled()) {
                 bundle.putString(RichPushConstants.EXTRA_DEEP_LINK_URL, message.getDeepLinkUrl());

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
@@ -37,7 +37,7 @@ public class NotificationWorker extends IntentService {
 
         Message message = null;
         try {
-            message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+            message = Message.parseIntent(intent);
         } catch (Exception ignore) {
         }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -50,7 +50,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
 
             Message message = null;
             try {
-                message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+                message = Message.parseIntent(intent);
             } catch (Exception ignore) {
             }
 
@@ -75,7 +75,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayProductPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getProductPage() != null) {
@@ -102,7 +102,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void addToCart(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getCartPage() != null) {
@@ -129,7 +129,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayCartPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getCartPage() != null) {
@@ -151,7 +151,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayOfferDisplayPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getOfferDisplayPage() != null) {
@@ -173,7 +173,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void openApp(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.parseBundle(bundle);
         if (message != null) {
             PackageManager packageManager = context.getPackageManager();
             Intent launcherIntent = packageManager.getLaunchIntentForPackage(context.getPackageName());


### PR DESCRIPTION
Samsung M31 does not pass custom objects (which are serializable) from notification content intent o the host app. To resolve this, we removed serializable implementation and leveraged primitive datatype String to get this done using JSON.