### PR TITLE
[MOBL-556] optimise images in carousel notifications

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -6,7 +6,7 @@ ext {
     sdkGroup = 'com.blueshift'
     sdkArtifactName = 'android-sdk'
 
-    sdkVersion = '3.1.7'
+    sdkVersion = '3.1.7-alpha'
     sdkVersionDesc = 'Blueshift Android SDK v' + sdkVersion
     sdkVcsTag = sdkVersion
 

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -6,7 +6,7 @@ ext {
     sdkGroup = 'com.blueshift'
     sdkArtifactName = 'android-sdk'
 
-    sdkVersion = '3.1.7-alpha'
+    sdkVersion = '3.1.7'
     sdkVersionDesc = 'Blueshift Android SDK v' + sdkVersion
     sdkVcsTag = sdkVersion
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -7,7 +7,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -28,9 +27,6 @@ import com.blueshift.model.Configuration;
 import com.blueshift.util.CommonUtils;
 import com.blueshift.util.NotificationUtils;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -196,17 +192,6 @@ class CustomNotificationFactory {
                     }
 
                     if (bitmap != null) {
-                        try {
-                            // compress image and set in notification
-                            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, byteArrayOutputStream);
-                            byte[] bytes = byteArrayOutputStream.toByteArray();
-                            int len = bytes != null ? bytes.length : 0;
-                            BlueshiftLogger.d(LOG_TAG, "image size: " + len + " bytes, url: " + element.getImageUrl());
-                        } catch (Exception e) {
-                            BlueshiftLogger.e(LOG_TAG, e);
-                        }
-
                         contentView.setImageViewBitmap(R.id.big_picture, bitmap);
                     } else {
                         // show the app icon as place holder for corrupted image
@@ -639,7 +624,11 @@ class CustomNotificationFactory {
                 if (elements != null) {
                     for (CarouselElement element : elements) {
                         // Load image using remote URL.
-                        Bitmap bitmap = NotificationUtils.loadScaledBitmap(element.getImageUrl(), 300, 150);
+                        Bitmap bitmap = NotificationUtils.loadScaledBitmap(
+                                element.getImageUrl(),
+                                RichPushConstants.BIG_IMAGE_WIDTH,
+                                RichPushConstants.BIG_IMAGE_HEIGHT);
+
                         if (bitmap == null) continue;
 
                         // Set the image into the view.

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -639,7 +639,7 @@ class CustomNotificationFactory {
                 if (elements != null) {
                     for (CarouselElement element : elements) {
                         // Load image using remote URL.
-                        Bitmap bitmap = NotificationUtils.loadScaledBitmap(element.getImageUrl(), 400, 200);
+                        Bitmap bitmap = NotificationUtils.loadScaledBitmap(element.getImageUrl(), 300, 150);
                         if (bitmap == null) continue;
 
                         // Set the image into the view.

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
@@ -8,6 +8,9 @@ import android.content.Context;
  *         https://github.com/rahulrvp
  */
 public final class RichPushConstants {
+    public static final int BIG_IMAGE_WIDTH = 300;
+    public static final int BIG_IMAGE_HEIGHT = 150;
+
     public static final String DEFAULT_CHANNEL_ID = "bsft_channel_General";
     public static final String DEFAULT_CHANNEL_NAME = "General";
     public static final String EXTRA_MESSAGE = "message";

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -25,8 +25,6 @@ import com.blueshift.rich_push.CarouselElement;
 import com.blueshift.rich_push.Message;
 import com.blueshift.rich_push.RichPushConstants;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -70,12 +68,10 @@ public class NotificationUtils {
                     FileOutputStream fileOutputStream = null;
                     try {
                         if (element != null) {
-                            // download image
-                            URL imageURL = new URL(element.getImageUrl());
-                            Bitmap bitmap = BitmapFactory.decodeStream(imageURL.openStream());
-
-                            // resize image
-                            bitmap = resizeImageForDevice(context, bitmap);
+                            Bitmap bitmap = NotificationUtils.loadScaledBitmap(
+                                    element.getImageUrl(),
+                                    RichPushConstants.BIG_IMAGE_WIDTH,
+                                    RichPushConstants.BIG_IMAGE_HEIGHT);
 
                             // save image
                             String imageUrl = element.getImageUrl();
@@ -84,7 +80,7 @@ public class NotificationUtils {
                             if (!TextUtils.isEmpty(fileName)) {
                                 if (bitmap != null) {
                                     fileOutputStream = context.openFileOutput(fileName, Context.MODE_PRIVATE);
-                                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, fileOutputStream);
+                                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fileOutputStream);
                                     fileOutputStream.close();
                                 }
                             }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -521,29 +521,6 @@ public class NotificationUtils {
         return launcherIntent;
     }
 
-    public static Bitmap compressBitmap(Bitmap input) {
-        if (input != null) {
-            try {
-                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                input.compress(Bitmap.CompressFormat.JPEG, 90, byteArrayOutputStream);
-
-                byte[] bytes = byteArrayOutputStream.toByteArray();
-
-                ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-                Bitmap compressed = BitmapFactory.decodeStream(byteArrayInputStream);
-
-                int len = bytes != null ? bytes.length : 0;
-                BlueshiftLogger.d(LOG_TAG, "Compressed image size: " + len + " bytes.");
-
-                return compressed;
-            } catch (Exception e) {
-                BlueshiftLogger.e(LOG_TAG, e);
-            }
-        }
-
-        return input;
-    }
-
     public static Bitmap loadScaledBitmap(String url, int reqWidth, int reqHeight) {
         try {
             final BitmapFactory.Options options = new BitmapFactory.Options();
@@ -556,9 +533,10 @@ public class NotificationUtils {
 
             Bitmap raw = BitmapFactory.decodeStream(new URL(url).openStream(), new Rect(), options);
             if (raw != null) {
-                Bitmap compressed = compressBitmap(raw);
-                raw.recycle();
-                return compressed;
+                BlueshiftLogger.d(LOG_TAG, "Bitmap (" +
+                        "size: " + (raw.getByteCount() / 1024f) / 1024f + " MB\t" +
+                        "url: " + url + ")");
+                return raw;
             }
         } catch (Exception e) {
             BlueshiftLogger.e(LOG_TAG, e);

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -102,35 +102,6 @@ public class NotificationUtils {
     }
 
     /**
-     * This method re-sizes the bitmap to have aspect ration 2:1 based on the device's dimension.
-     *
-     * @param context      valid context object
-     * @param sourceBitmap the image to resize
-     * @return resized image
-     */
-    public static Bitmap resizeImageForDevice(Context context, Bitmap sourceBitmap) {
-        Bitmap resizedBitmap = null;
-
-        if (sourceBitmap != null) {
-            if (sourceBitmap.getWidth() > sourceBitmap.getHeight()) {
-                DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
-
-                // ideal image aspect ratio for notification is 2:1
-                int newWidth = displayMetrics.widthPixels;
-                int newHeight = newWidth / 2;
-
-                resizedBitmap = Bitmap.createScaledBitmap(sourceBitmap, newWidth, newHeight, true);
-            }
-        }
-
-        if (resizedBitmap == null) {
-            resizedBitmap = sourceBitmap;
-        }
-
-        return resizedBitmap;
-    }
-
-    /**
      * Loads the image stored inside app's private file location
      *
      * @param context  valid context object


### PR DESCRIPTION
This patch reduces the image size to avoid issues with push notifications in Android 11