### PR TITLE
[MOBL-580] send timestamp in all events

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1197,6 +1197,9 @@ public class Blueshift {
                 q.append(BlueshiftConstants.KEY_APP_NAME).append("=").append(pkgName);
             }
 
+            appendAnd(q);
+            q.append(BlueshiftConstants.KEY_TIMESTAMP).append("=").append(CommonUtils.getCurrentUtcTimestamp());
+
             if (extras != null && extras.size() > 0) {
                 String clickUrl = null;
                 Set<String> keys = extras.keySet();

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1077,10 +1077,8 @@ public class Blueshift {
 
     public void trackInAppMessageView(InAppMessage inAppMessage) {
         if (inAppMessage != null) {
-            HashMap<String, Object> extra = new HashMap<>();
-            extra.put(BlueshiftConstants.KEY_TIMESTAMP, inAppMessage.getTimestamp());
-
-            trackCampaignEventAsync(InAppConstants.EVENT_OPEN, inAppMessage.getCampaignParamsMap(), extra);
+            trackCampaignEventAsync(
+                    InAppConstants.EVENT_OPEN, inAppMessage.getCampaignParamsMap(), null);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -32,6 +32,7 @@ import com.blueshift.request_queue.RequestQueue;
 import com.blueshift.rich_push.Message;
 import com.blueshift.type.SubscriptionState;
 import com.blueshift.util.BlueshiftUtils;
+import com.blueshift.util.CommonUtils;
 import com.blueshift.util.DeviceUtils;
 import com.blueshift.util.NetworkUtils;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -50,8 +51,8 @@ import java.util.Set;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 17/2/15 @ 3:08 PM
- *         https://github.com/rahulrvp
+ * Created on 17/2/15 @ 3:08 PM
+ * https://github.com/rahulrvp
  */
 public class Blueshift {
     private static final String LOG_TAG = Blueshift.class.getSimpleName();
@@ -465,8 +466,8 @@ public class Blueshift {
             BlueshiftJSONObject eventParams = new BlueshiftJSONObject();
 
             try {
-                eventParams.put(BlueshiftConstants.KEY_TIMESTAMP, System.currentTimeMillis() / 1000);
                 eventParams.put(BlueshiftConstants.KEY_EVENT, eventName);
+                eventParams.put(BlueshiftConstants.KEY_TIMESTAMP, CommonUtils.getCurrentUtcTimestamp());
             } catch (JSONException e) {
                 BlueshiftLogger.e(LOG_TAG, e);
             }

--- a/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
@@ -11,13 +11,15 @@ import android.util.TypedValue;
 import com.blueshift.BlueshiftLogger;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 17/01/18 @ 4:41 PM
- *         https://github.com/rahulrvp
+ * Created on 17/01/18 @ 4:41 PM
+ * https://github.com/rahulrvp
  */
 
 
@@ -90,5 +92,13 @@ public class CommonUtils {
         }
 
         return false;
+    }
+
+    public static String getCurrentUtcTimestamp() {
+        Date now = new Date(System.currentTimeMillis());
+        SimpleDateFormat sdf = new SimpleDateFormat(
+                "yyyy-MM-dd'T'hh:mm:ss.SSSSSS'Z'", Locale.getDefault());
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(now);
     }
 }


### PR DESCRIPTION
This change will send the UTC timestamp of the event creation time, from the client-side to Blueshift as part of all events.