### PR TITLE
v3.1.8

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -32,6 +32,7 @@ import com.blueshift.request_queue.RequestQueue;
 import com.blueshift.rich_push.Message;
 import com.blueshift.type.SubscriptionState;
 import com.blueshift.util.BlueshiftUtils;
+import com.blueshift.util.CommonUtils;
 import com.blueshift.util.DeviceUtils;
 import com.blueshift.util.NetworkUtils;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -50,8 +51,8 @@ import java.util.Set;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 17/2/15 @ 3:08 PM
- *         https://github.com/rahulrvp
+ * Created on 17/2/15 @ 3:08 PM
+ * https://github.com/rahulrvp
  */
 public class Blueshift {
     private static final String LOG_TAG = Blueshift.class.getSimpleName();
@@ -465,8 +466,8 @@ public class Blueshift {
             BlueshiftJSONObject eventParams = new BlueshiftJSONObject();
 
             try {
-                eventParams.put(BlueshiftConstants.KEY_TIMESTAMP, System.currentTimeMillis() / 1000);
                 eventParams.put(BlueshiftConstants.KEY_EVENT, eventName);
+                eventParams.put(BlueshiftConstants.KEY_TIMESTAMP, CommonUtils.getCurrentUtcTimestamp());
             } catch (JSONException e) {
                 BlueshiftLogger.e(LOG_TAG, e);
             }
@@ -1076,10 +1077,8 @@ public class Blueshift {
 
     public void trackInAppMessageView(InAppMessage inAppMessage) {
         if (inAppMessage != null) {
-            HashMap<String, Object> extra = new HashMap<>();
-            extra.put(BlueshiftConstants.KEY_TIMESTAMP, inAppMessage.getTimestamp());
-
-            trackCampaignEventAsync(InAppConstants.EVENT_OPEN, inAppMessage.getCampaignParamsMap(), extra);
+            trackCampaignEventAsync(
+                    InAppConstants.EVENT_OPEN, inAppMessage.getCampaignParamsMap(), null);
         }
     }
 
@@ -1195,6 +1194,9 @@ public class Blueshift {
                 appendAnd(q);
                 q.append(BlueshiftConstants.KEY_APP_NAME).append("=").append(pkgName);
             }
+
+            appendAnd(q);
+            q.append(BlueshiftConstants.KEY_TIMESTAMP).append("=").append(CommonUtils.getCurrentUtcTimestamp());
 
             if (extras != null && extras.size() > 0) {
                 String clickUrl = null;

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -40,6 +40,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
+import com.google.gson.Gson;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -482,9 +483,11 @@ public class Blueshift {
                 eventParams.putAll(params);
             }
 
+            HashMap<String, Object> map = eventParams.toHasMap();
+
             if (canBatchThisEvent) {
                 Event event = new Event();
-                event.setEventParams(eventParams.toHasMap());
+                event.setEventParams(map);
 
                 BlueshiftLogger.i(LOG_TAG, "Adding event to events table for batching.");
 
@@ -495,7 +498,7 @@ public class Blueshift {
                 request.setPendingRetryCount(RequestQueue.DEFAULT_RETRY_COUNT);
                 request.setUrl(BlueshiftConstants.EVENT_API_URL);
                 request.setMethod(Method.POST);
-                request.setParamJson(eventParams.toString());
+                request.setParamJson(new Gson().toJson(map));
 
                 BlueshiftLogger.i(LOG_TAG, "Adding real-time event to request queue.");
 

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -635,8 +635,9 @@ public class InAppManager {
                             // image background will be at position 0 if available
                             View view = rootView.getChildAt(0);
                             if (view instanceof ImageView) {
-                                // background image added, now we need to match it with the size
-                                applyDimensionsToView(view, modalWidth, modalHeight);
+                                // background image is present and it will fill the parent view
+                                // automatically. Now let's adjust the dimensions of the parent view
+                                // to match the dimensions of the dialog container.
 
                                 if (rootView.getChildCount() > 1) {
                                     View contentView = rootView.getChildAt(1);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
@@ -11,13 +11,11 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
-import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -76,7 +74,11 @@ public abstract class InAppMessageView extends RelativeLayout {
         if (!TextUtils.isEmpty(url)) {
             ImageView imageView = new ImageView(getContext());
             imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
-            addView(imageView);
+
+            LayoutParams lp = new LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT);
+            addView(imageView, lp);
 
             InAppUtils.loadImageAsync(imageView, url);
         }

--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
@@ -14,7 +14,6 @@ import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.rich_push.Message;
 import com.blueshift.rich_push.RichPushConstants;
-import com.blueshift.util.NetworkUtils;
 import com.blueshift.util.NotificationUtils;
 
 import java.util.HashMap;
@@ -22,8 +21,8 @@ import java.util.HashMap;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 22/12/17 @ 3:25 PM
- *         https://github.com/rahulrvp
+ * Created on 22/12/17 @ 3:25 PM
+ * https://github.com/rahulrvp
  */
 
 public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
@@ -31,18 +30,13 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
     private static final String LOG_TAG = "NotificationClick";
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onResume() {
+        super.onResume();
 
-        if (getIntent() != null) {
-            Bundle extraBundle = getIntent().getExtras();
-            String action = getIntent().getAction();
-
-            processAction(action, extraBundle);
+        Intent intent = getIntent();
+        if (intent != null) {
+            processAction(intent.getAction(), intent.getExtras());
         }
-
-        // close activity once action is taken.
-        finish();
     }
 
     protected void processAction(String action, Bundle extraBundle) {

--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
@@ -27,8 +27,6 @@ import java.util.HashMap;
 
 public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
 
-    private static final String LOG_TAG = "NotificationClick";
-
     @Override
     protected void onResume() {
         super.onResume();
@@ -40,70 +38,6 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
     }
 
     protected void processAction(String action, Bundle extraBundle) {
-        if (extraBundle != null) {
-            Message message = (Message) extraBundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
-            if (message != null) {
-                try {
-                    HashMap<String, Object> clickAttr = new HashMap<>();
-                    String deepLink = extraBundle.getString(RichPushConstants.EXTRA_DEEP_LINK_URL);
-                    clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, deepLink);
-
-                    // mark 'click'
-                    Blueshift.getInstance(this).trackNotificationClick(message, clickAttr);
-
-                    Intent intent = null;
-
-                    if (!TextUtils.isEmpty(action)) {
-                        if (action.equals(RichPushConstants.ACTION_OPEN_APP(this))) {
-                            intent = NotificationUtils.getOpenAppIntent(this, message);
-                        } else if (action.equals(RichPushConstants.ACTION_VIEW(this))) {
-                            intent = NotificationUtils.getViewProductActivityIntent(this, message);
-                        } else if (action.equals(RichPushConstants.ACTION_BUY(this))) {
-                            intent = NotificationUtils.getAddToCartActivityIntent(this, message);
-                        } else if (action.equals(RichPushConstants.ACTION_OPEN_CART(this))) {
-                            intent = NotificationUtils.getViewCartActivityIntent(this, message);
-                        } else if (action.equals(RichPushConstants.ACTION_OPEN_OFFER_PAGE(this))) {
-                            intent = NotificationUtils.getViewOffersActivityIntent(this, message);
-                        }
-                    }
-
-                    if (intent == null) {
-                        // make sure the app is opened even if no category deep-links are available
-                        intent = NotificationUtils.getOpenAppIntent(this, message);
-                    }
-
-                    // add complete bundle to the intent.
-                    intent.putExtras(extraBundle);
-
-                    // Note: This will create a new task and launch the app with the corresponding
-                    // activity. As per the docs, the dev should add parent activity to all the
-                    // activities registered in the manifest in order to get the back stack working
-                    // doc: https://developer.android.com/training/notify-user/navigation#DirectEntry
-                    TaskStackBuilder.create(this).addNextIntentWithParentStack(intent).startActivities();
-
-                    // mark 'app_open'
-                    Blueshift.getInstance(this).trackNotificationPageOpen(message, false);
-
-                    // remove cached images(if any) for this notification
-                    NotificationUtils.removeCachedCarouselImages(this, message);
-
-                    // remove notification from tray
-                    NotificationManager notificationManager =
-                            (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
-                    if (notificationManager != null) {
-                        int notificationID = intent.getIntExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, 0);
-                        notificationManager.cancel(notificationID);
-                    }
-
-                    sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
-                } catch (Exception e) {
-                    BlueshiftLogger.e(LOG_TAG, e);
-                }
-            } else {
-                BlueshiftLogger.d(LOG_TAG, "No message found inside bundle.");
-            }
-        } else {
-            BlueshiftLogger.d(LOG_TAG, "No bundle found from the notification click event.");
-        }
+        NotificationUtils.processNotificationClick(this, action, extraBundle);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -7,7 +7,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -28,8 +27,6 @@ import com.blueshift.model.Configuration;
 import com.blueshift.util.CommonUtils;
 import com.blueshift.util.NotificationUtils;
 
-import java.io.IOException;
-import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -626,35 +623,35 @@ class CustomNotificationFactory {
                 CarouselElement[] elements = message.getCarouselElements();
                 if (elements != null) {
                     for (CarouselElement element : elements) {
-                        try {
-                            // Load image using remote URL.
-                            URL imageURL = new URL(element.getImageUrl());
-                            Bitmap bitmap = BitmapFactory.decodeStream(imageURL.openStream());
+                        // Load image using remote URL.
+                        Bitmap bitmap = NotificationUtils.loadScaledBitmap(
+                                element.getImageUrl(),
+                                RichPushConstants.BIG_IMAGE_WIDTH,
+                                RichPushConstants.BIG_IMAGE_HEIGHT);
 
-                            // Set the image into the view.
-                            RemoteViews viewFlipperEntry = new RemoteViews(packageName, R.layout.bsft_carousel_view_flipper_entry);
-                            viewFlipperEntry.setImageViewBitmap(R.id.carousel_image_view, bitmap);
+                        if (bitmap == null) continue;
 
-                            // Attach an onClick pending intent.
-                            viewFlipperEntry.setOnClickPendingIntent(
-                                    R.id.carousel_image_view,
-                                    getCarouselImageClickPendingIntent(context, message, element, notificationId)
-                            );
+                        // Set the image into the view.
+                        RemoteViews viewFlipperEntry = new RemoteViews(packageName, R.layout.bsft_carousel_view_flipper_entry);
+                        viewFlipperEntry.setImageViewBitmap(R.id.carousel_image_view, bitmap);
 
-                            // remove any view found on the overlay container
-                            viewFlipperEntry.removeAllViews(R.id.carousel_overlay_container);
+                        // Attach an onClick pending intent.
+                        viewFlipperEntry.setOnClickPendingIntent(
+                                R.id.carousel_image_view,
+                                getCarouselImageClickPendingIntent(context, message, element, notificationId)
+                        );
 
-                            // look for overlay content and add it in the container layout (if found)
-                            RemoteViews overlay = getOverlayView(context, element);
-                            if (overlay != null) {
-                                viewFlipperEntry.addView(R.id.carousel_overlay_container, overlay);
-                            }
+                        // remove any view found on the overlay container
+                        viewFlipperEntry.removeAllViews(R.id.carousel_overlay_container);
 
-                            // Add the image into ViewFlipper.
-                            viewFlipper.addView(R.id.view_flipper, viewFlipperEntry);
-                        } catch (IOException e) {
-                            BlueshiftLogger.e(LOG_TAG, e);
+                        // look for overlay content and add it in the container layout (if found)
+                        RemoteViews overlay = getOverlayView(context, element);
+                        if (overlay != null) {
+                            viewFlipperEntry.addView(R.id.carousel_overlay_container, overlay);
                         }
+
+                        // Add the image into ViewFlipper.
+                        viewFlipper.addView(R.id.view_flipper, viewFlipperEntry);
                     }
                 }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
@@ -8,6 +8,9 @@ import android.content.Context;
  *         https://github.com/rahulrvp
  */
 public final class RichPushConstants {
+    public static final int BIG_IMAGE_WIDTH = 300;
+    public static final int BIG_IMAGE_HEIGHT = 150;
+
     public static final String DEFAULT_CHANNEL_ID = "bsft_channel_General";
     public static final String DEFAULT_CHANNEL_NAME = "General";
     public static final String EXTRA_MESSAGE = "message";

--- a/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
@@ -11,13 +11,15 @@ import android.util.TypedValue;
 import com.blueshift.BlueshiftLogger;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 17/01/18 @ 4:41 PM
- *         https://github.com/rahulrvp
+ * Created on 17/01/18 @ 4:41 PM
+ * https://github.com/rahulrvp
  */
 
 
@@ -90,5 +92,13 @@ public class CommonUtils {
         }
 
         return false;
+    }
+
+    public static String getCurrentUtcTimestamp() {
+        Date now = new Date(System.currentTimeMillis());
+        SimpleDateFormat sdf = new SimpleDateFormat(
+                "yyyy-MM-dd'T'hh:mm:ss.SSSSSS'Z'", Locale.getDefault());
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(now);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -14,10 +14,11 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.TaskStackBuilder;
 import android.text.TextUtils;
-import android.util.DisplayMetrics;
 
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.model.Configuration;
 import com.blueshift.pn.BlueshiftNotificationEventsActivity;
@@ -31,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -533,5 +535,98 @@ public class NotificationUtils {
         }
 
         return inSampleSize;
+    }
+
+    /**
+     * This is a helper method that can decide what needs to be done when someone clicks on push msg.
+     * This method is being called by the sdk from the {@link BlueshiftNotificationEventsActivity}
+     * The host app can make use of this method if they would like to override the clicks on push msg.
+     *
+     * @param context valid context object
+     * @param action  action from the intent
+     * @param bundle  bundle inside the intent
+     */
+    public static void processNotificationClick(Context context, String action, Bundle bundle) {
+        if (context != null && action != null && bundle != null) {
+            Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+            if (message != null) {
+                try {
+                    HashMap<String, Object> clickAttr = new HashMap<>();
+                    String deepLink = bundle.getString(RichPushConstants.EXTRA_DEEP_LINK_URL);
+                    clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, deepLink);
+
+                    // mark 'click'
+                    Blueshift.getInstance(context).trackNotificationClick(message, clickAttr);
+
+                    Intent intent = null;
+
+                    if (!TextUtils.isEmpty(action)) {
+                        if (action.equals(RichPushConstants.ACTION_OPEN_APP(context))) {
+                            intent = NotificationUtils.getOpenAppIntent(context, message);
+                        } else if (action.equals(RichPushConstants.ACTION_VIEW(context))) {
+                            intent = NotificationUtils.getViewProductActivityIntent(context, message);
+                        } else if (action.equals(RichPushConstants.ACTION_BUY(context))) {
+                            intent = NotificationUtils.getAddToCartActivityIntent(context, message);
+                        } else if (action.equals(RichPushConstants.ACTION_OPEN_CART(context))) {
+                            intent = NotificationUtils.getViewCartActivityIntent(context, message);
+                        } else if (action.equals(RichPushConstants.ACTION_OPEN_OFFER_PAGE(context))) {
+                            intent = NotificationUtils.getViewOffersActivityIntent(context, message);
+                        }
+                    }
+
+                    if (intent == null) {
+                        // make sure the app is opened even if no category deep-links are available
+                        intent = NotificationUtils.getOpenAppIntent(context, message);
+                    }
+
+                    // add complete bundle to the intent.
+                    intent.putExtras(bundle);
+
+                    // Note: This will create a new task and launch the app with the corresponding
+                    // activity. As per the docs, the dev should add parent activity to all the
+                    // activities registered in the manifest in order to get the back stack working
+                    // doc: https://developer.android.com/training/notify-user/navigation#DirectEntry
+                    TaskStackBuilder.create(context).addNextIntentWithParentStack(intent).startActivities();
+
+                    // mark 'app_open'
+                    Blueshift.getInstance(context).trackNotificationPageOpen(message, false);
+
+                    // remove cached images(if any) for this notification
+                    NotificationUtils.removeCachedCarouselImages(context, message);
+
+                    // remove notification from tray
+                    NotificationManager notificationManager =
+                            (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    if (notificationManager != null) {
+                        int notificationID = intent.getIntExtra(RichPushConstants.EXTRA_NOTIFICATION_ID, 0);
+                        notificationManager.cancel(notificationID);
+                    }
+
+                    context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+                } catch (Exception e) {
+                    BlueshiftLogger.e(LOG_TAG, e);
+                }
+            } else {
+                BlueshiftLogger.d(LOG_TAG, "No message found inside bundle.");
+            }
+        } else {
+            BlueshiftLogger.d(LOG_TAG, "processNotificationClick: Invalid arguments " +
+                    "(context: " + context + ", action: " + action + ", bundle: " + bundle + ").");
+        }
+    }
+
+    /**
+     * Simplified version of processNotificationClick(context, action, bundle)
+     *
+     * @param context valid context object
+     * @param intent  valid intent
+     */
+    public static void processNotificationClick(Context context, Intent intent) {
+        if (context != null && intent != null) {
+            processNotificationClick(context, intent.getAction(), intent.getExtras());
+        } else {
+            BlueshiftLogger.d(LOG_TAG, "processNotificationClick: Invalid arguments " +
+                    "(context: " + context + ", intent: " + intent + ").");
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -545,8 +545,9 @@ public class NotificationUtils {
      * @param context valid context object
      * @param action  action from the intent
      * @param bundle  bundle inside the intent
+     * @return true: if the click was handled by the sdk, false: if the click was not handled by the sdk.
      */
-    public static void processNotificationClick(Context context, String action, Bundle bundle) {
+    public static boolean processNotificationClick(Context context, String action, Bundle bundle) {
         if (context != null && action != null && bundle != null) {
             Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
             if (message != null) {
@@ -603,6 +604,9 @@ public class NotificationUtils {
                     }
 
                     context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+
+                    // click was handled by Blueshift SDK
+                    return true;
                 } catch (Exception e) {
                     BlueshiftLogger.e(LOG_TAG, e);
                 }
@@ -613,6 +617,9 @@ public class NotificationUtils {
             BlueshiftLogger.d(LOG_TAG, "processNotificationClick: Invalid arguments " +
                     "(context: " + context + ", action: " + action + ", bundle: " + bundle + ").");
         }
+
+        // click was not handled by Blueshift SDK
+        return false;
     }
 
     /**
@@ -621,12 +628,13 @@ public class NotificationUtils {
      * @param context valid context object
      * @param intent  valid intent
      */
-    public static void processNotificationClick(Context context, Intent intent) {
+    public static boolean processNotificationClick(Context context, Intent intent) {
         if (context != null && intent != null) {
-            processNotificationClick(context, intent.getAction(), intent.getExtras());
+            return processNotificationClick(context, intent.getAction(), intent.getExtras());
         } else {
             BlueshiftLogger.d(LOG_TAG, "processNotificationClick: Invalid arguments " +
                     "(context: " + context + ", intent: " + intent + ").");
+            return false;
         }
     }
 }


### PR DESCRIPTION
- Using scaled images in the carousel push messages (animated and non-animated) to reduce memory usage.
- Added local timestamp to all events' attributes for better tracking.
- Moved the click tracking from onCreate to onResume of the BlueshiftNotificationEventsActivity to avoid timeout warning.
- Added helper method for tracking notification click. Host app can use this method to track the clicks without extending the BlueshiftNotificationEventsActivity class.
- Added check to make sure the presence of device_id in event params before the API call.
- Bug-fix: Sending an array of objects properly inside event params. Fix for a bug introduced in v3.1.7.
- Bug-fix: Glitch in scaling background image when app is brought to foreground when in-app is in display fixed.