### PR TITLE
[MOBL-664] deprecate the "alert" notification type

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -18,7 +18,11 @@ import com.blueshift.model.Configuration;
  * <p>
  * This activity is responsible for creating dialog notifications.
  * Currently supports two types of dialogues.
+ *
+ * @deprecated This Activity is deprecated as the notification_type "alert" is deprecated.
+ * This class will be removed from the project later in time.
  */
+@Deprecated
 public class NotificationActivity extends AppCompatActivity {
 
     private Context mContext;

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -33,8 +33,8 @@ import java.util.Random;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 18/2/15 @ 12:22 PM
- *         https://github.com/rahulrvp
+ * Created on 18/2/15 @ 12:22 PM
+ * https://github.com/rahulrvp
  */
 public class NotificationFactory {
     private final static String LOG_TAG = NotificationFactory.class.getSimpleName();
@@ -74,6 +74,16 @@ public class NotificationFactory {
         }
     }
 
+    /**
+     * This method is responsible for showing a popup dialog when receiving a push message with
+     * notification_type "alert".
+     *
+     * @param context context object
+     * @param message message object
+     * @deprecated This method is deprecated because Blueshift has deprecated the notification type
+     * "alert" that displays popup dialogs on receiving the push. Use in-app messages instead.
+     */
+    @Deprecated
     private static void buildAndShowAlertDialog(final Context context, final Message message) {
         if (context != null && message != null) {
             final Handler handler = BlueshiftExecutor.getInstance().getMyHandler();
@@ -98,6 +108,7 @@ public class NotificationFactory {
         }
     }
 
+    @Deprecated
     private static void launchNotificationActivity(Context context, Message message, boolean appIsInForeground) {
         if (context != null && message != null) {
             Intent notificationIntent = new Intent(context, NotificationActivity.class);


### PR DESCRIPTION
adding deprecation notice to the soon to be removed methods on the SDK side for notification_type "alert"

> Note: This does not remove the code or functionality from the SDK. This only adds a notice that we are not building on this feature anymore.