### PR TITLE
[MOBL-662] Add more callbacks to push and in-app

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -63,6 +63,8 @@ public class Blueshift {
     private Context mContext;
     private static Configuration mConfiguration;
     private static Blueshift instance = null;
+    private static BlueshiftPushListener blueshiftPushListener;
+    private static BlueshiftInAppListener blueshiftInAppListener;
 
     public enum DeviceIdSource {
         ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME, CUSTOM
@@ -86,6 +88,22 @@ public class Blueshift {
         }
 
         return instance;
+    }
+
+    public static BlueshiftPushListener getBlueshiftPushListener() {
+        return blueshiftPushListener;
+    }
+
+    public static BlueshiftInAppListener getBlueshiftInAppListener() {
+        return blueshiftInAppListener;
+    }
+
+    public static void setBlueshiftPushListener(BlueshiftPushListener pushListener) {
+        blueshiftPushListener = pushListener;
+    }
+
+    public static void setBlueshiftInAppListener(BlueshiftInAppListener inAppListener) {
+        blueshiftInAppListener = inAppListener;
     }
 
     public void registerForInAppMessages(Activity activity) {

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
@@ -3,9 +3,9 @@ package com.blueshift;
 import java.util.Map;
 
 public interface BlueshiftInAppListener {
-    void onInAppDelivered(Map<String, String> attributes);
+    void onInAppDelivered(Map<String, Object> attributes);
 
-    void onInAppOpened(Map<String, String> attributes);
+    void onInAppOpened(Map<String, Object> attributes);
 
-    void onInAppClicked(Map<String, String> attributes);
+    void onInAppClicked(Map<String, Object> attributes);
 }

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
@@ -1,0 +1,11 @@
+package com.blueshift;
+
+import java.util.Map;
+
+public interface BlueshiftInAppListener {
+    void onInAppDelivered(Map<String, String> attributes);
+
+    void onInAppOpened(Map<String, String> attributes);
+
+    void onInAppClicked(Map<String, String> attributes);
+}

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftPushListener.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftPushListener.java
@@ -1,0 +1,9 @@
+package com.blueshift;
+
+import java.util.Map;
+
+public interface BlueshiftPushListener {
+    void onPushDelivered(Map<String, Object> attributes);
+
+    void onPushClicked(Map<String, Object> attributes);
+}

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -180,28 +180,14 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
         return false;
     }
 
-    public static void handlePushMessage(Context context, Intent intent) {
-        try {
-            if (context != null && intent != null) {
-                Bundle bundle = intent.getExtras();
-                if (bundle != null) {
-                    Map<String, String> map = new HashMap<>();
-                    for (String key : bundle.keySet()) {
-                        Object val = bundle.get(key);
-                        if (val != null) map.put(key, String.valueOf(val));
-                    }
 
-                    BlueshiftMessagingService service = new BlueshiftMessagingService();
-                    service.handleDataMessage(context, map);
-                }
-            } else {
-                BlueshiftLogger.e(LOG_TAG, "Could not handle push. Context is " + context + " and Intent is" + intent);
-            }
-        } catch (Exception e) {
-            BlueshiftLogger.e(LOG_TAG, e);
-        }
-    }
-
+    /**
+     * This method takes care of parsing the data payload to see if the push belongs to Blueshift
+     * and what action needs to be taken based on the payload content.
+     *
+     * @param context A valid {@link Context} object from the caller
+     * @param data    A valid data payload in the form of a {@link Map}
+     */
     private void handleDataMessage(Context context, Map<String, String> data) {
         if (data != null) {
             logPayload(data);
@@ -413,5 +399,57 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
         Blueshift
                 .getInstance(this)
                 .identifyUserByDeviceId(deviceId, null, false);
+    }
+
+    /**
+     * This method is required by the Blueshift-mParticle-Kit to do the push rendering when a push
+     * message is handed over to the kit by the mParticle SDK
+     *
+     * @param context {@link Context} object from the mParticle kit callback
+     * @param intent  {@link Intent} object from the mParticle kit callback
+     */
+    public static void handlePushMessage(Context context, Intent intent) {
+        try {
+            if (context != null && intent != null) {
+                Bundle bundle = intent.getExtras();
+                if (bundle != null) {
+                    Map<String, String> map = new HashMap<>();
+                    for (String key : bundle.keySet()) {
+                        Object val = bundle.get(key);
+                        if (val != null) map.put(key, String.valueOf(val));
+                    }
+
+                    BlueshiftMessagingService service = new BlueshiftMessagingService();
+                    service.handleDataMessage(context, map);
+                }
+            } else {
+                BlueshiftLogger.e(LOG_TAG, "Could not handle push. Context is " + context + " and Intent is" + intent);
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+    }
+
+    /**
+     * Helper method for the host app to invoke the onMessageReceived method of the BlueshiftMessagingService class
+     *
+     * @param context       Valid {@link Context} object
+     * @param remoteMessage Valid {@link RemoteMessage} object
+     */
+    public static void handleMessageReceived(Context context, RemoteMessage remoteMessage) {
+        if (context != null && remoteMessage != null) {
+            new BlueshiftMessagingService().handleDataMessage(context, remoteMessage.getData());
+        }
+    }
+
+    /**
+     * Helper method for the host app to invoke the onNewToken method of the BlueshiftMessagingService class
+     *
+     * @param newToken Valid new token provided by FCM
+     */
+    public static void handleNewToken(String newToken) {
+        if (newToken != null) {
+            new BlueshiftMessagingService().onNewToken(newToken);
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -298,7 +298,7 @@ public class InAppManager {
             BlueshiftLogger.d(LOG_TAG, "In-app message received. Message UUID: " + (inAppMessage != null ? inAppMessage.getMessageUuid() : null));
 
             if (inAppMessage != null) {
-                Blueshift.getInstance(context).trackInAppMessageDelivered(inAppMessage);
+                InAppUtils.invokeInAppDelivered(context, inAppMessage);
 
                 if (!inAppMessage.isExpired()) {
                     boolean inserted = InAppMessageStore.getInstance(context).insert(inAppMessage);
@@ -584,7 +584,7 @@ public class InAppManager {
         // dismiss the dialog and cleanup memory
         dismissAndCleanupDialog();
         // log the click event
-        Blueshift.getInstance(appContext).trackInAppMessageClick(inAppMessage, extras);
+        InAppUtils.invokeInAppClicked(appContext, inAppMessage, extras);
     }
 
     private static void invokeOnInAppViewed(InAppMessage inAppMessage) {
@@ -594,7 +594,7 @@ public class InAppManager {
         Context appContext = mActivity != null ? mActivity.getApplicationContext() : null;
         if (appContext != null) {
             // send stats
-            Blueshift.getInstance(appContext).trackInAppMessageView(inAppMessage);
+            InAppUtils.invokeInAppOpened(appContext, inAppMessage);
             // update with displayed at timing
             inAppMessage.setDisplayedAt(System.currentTimeMillis());
             InAppMessageStore.getInstance(appContext).update(inAppMessage);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
@@ -44,6 +44,30 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
     private String transaction_uuid;
     private String timestamp;
 
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(InAppConstants.TYPE, type);
+        map.put(InAppConstants.EXPIRES_AT, expires_at);
+        map.put(InAppConstants.TRIGGER, trigger);
+        map.put(InAppConstants.DISPLAY_ON, display_on);
+        map.put(InAppConstants.TEMPLATE_STYLE, template_style);
+        map.put(InAppConstants.TEMPLATE_STYLE_DARK, template_style_dark);
+        map.put(InAppConstants.CONTENT_STYLE, content_style);
+        map.put(InAppConstants.CONTENT_STYLE_DARK, content_style_dark);
+        map.put(InAppConstants.CONTENT, content);
+        map.put(InAppConstants.EXTRAS, extras);
+
+        map.put(Message.EXTRA_BSFT_MESSAGE_UUID, message_uuid);
+        map.put(Message.EXTRA_BSFT_EXPERIMENT_UUID, experiment_uuid);
+        map.put(Message.EXTRA_BSFT_USER_UUID, user_uuid);
+        map.put(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, transaction_uuid);
+
+        map.put(BlueshiftConstants.KEY_TIMESTAMP, timestamp);
+
+        return map;
+    }
+
     public static InAppMessage getInstance(JSONObject jsonObject) {
         try {
             String json = jsonObject.optString(InAppMessage.EXTRA_IN_APP);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
@@ -185,9 +185,7 @@ public abstract class InAppMessageView extends RelativeLayout {
                 JSONObject statsParams = getClickStatsJSONObject(element);
                 String androidLink = actionJson.optString(InAppConstants.ANDROID_LINK);
                 if (!TextUtils.isEmpty(androidLink)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(androidLink));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, androidLink);
                 }
 
                 if (InAppManager.getActionCallback() != null) {

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageViewHTML.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageViewHTML.java
@@ -63,9 +63,7 @@ public class InAppMessageViewHTML extends InAppMessageView {
             JSONObject statsParams = getClickStatsJSONObject(null);
             try {
                 if (!TextUtils.isEmpty(link)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(link));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, link);
                 }
             } catch (JSONException ignore) {
             }
@@ -97,9 +95,7 @@ public class InAppMessageViewHTML extends InAppMessageView {
             try {
                 String link = uri.toString();
                 if (!TextUtils.isEmpty(link)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(link));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, link);
                 }
             } catch (JSONException ignored) {
             }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -89,8 +89,7 @@ class CustomNotificationFactory {
                     manager.notify(notificationId, notification);
                 }
 
-                // Tracking the notification display.
-                Blueshift.getInstance(context).trackNotificationView(message);
+                NotificationUtils.invokePushDelivered(context, message);
             }
         }
     }
@@ -142,7 +141,7 @@ class CustomNotificationFactory {
 
                 if (!isUpdating) {
                     // Tracking the notification display for the first time
-                    Blueshift.getInstance(context).trackNotificationView(message);
+                    NotificationUtils.invokePushDelivered(context, message);
                 }
             }
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -5,11 +5,12 @@ import android.text.TextUtils;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 18/2/15 @ 12:20 PM
- *         https://github.com/rahulrvp
+ * Created on 18/2/15 @ 12:20 PM
+ * https://github.com/rahulrvp
  */
 public class Message implements Serializable {
     public static final String EXTRA_MESSAGE = "message";
@@ -29,7 +30,7 @@ public class Message implements Serializable {
     private String bsft_transaction_uuid; // present only with transactional campaign
     private Boolean bsft_seed_list_send; // test messages sent to seed list of users will have this
 
-    /**
+    /*
      * The following variables are used for parsing the 'message' payload.
      * They are the values used for creating the notification.
      */
@@ -164,6 +165,41 @@ public class Message implements Serializable {
     private String notification_channel_id;
     private String notification_channel_name;
     private String notification_channel_description;
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put(Message.EXTRA_BSFT_MESSAGE_UUID, bsft_message_uuid);
+        map.put(Message.EXTRA_BSFT_EXPERIMENT_UUID, bsft_experiment_uuid);
+        map.put(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, bsft_transaction_uuid);
+        map.put(Message.EXTRA_BSFT_USER_UUID, bsft_user_uuid);
+        map.put(Message.EXTRA_BSFT_SEED_LIST_SEND, bsft_seed_list_send);
+
+        map.put("notification_type", notification_type);
+        map.put("category", category);
+        map.put("content_title", content_title);
+        map.put("content_text", content_text);
+        map.put("content_sub_text", content_sub_text);
+        map.put("big_content_title", big_content_title);
+        map.put("big_content_summary_text", big_content_summary_text);
+        map.put("image_url", image_url);
+        map.put("carousel_elements", carousel_elements);
+        map.put("deep_link_url", deep_link_url);
+        map.put("url", url);
+        map.put("product_id", product_id);
+        map.put("sku", sku);
+        map.put("mrp", mrp);
+        map.put("price", price);
+        map.put("data", data);
+        map.put("notifications", notifications);
+        map.put("timestamp_to_display", timestamp_to_display);
+        map.put("timestamp_to_expire_display", timestamp_to_expire_display);
+        map.put("notification_channel_id", notification_channel_id);
+        map.put("notification_channel_name", notification_channel_name);
+        map.put("notification_channel_description", notification_channel_description);
+
+        return map;
+    }
 
     /**
      * The following are the get / set methods for the above declared variables.

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -12,6 +12,7 @@ import android.view.Window;
 import com.blueshift.Blueshift;
 import com.blueshift.R;
 import com.blueshift.model.Configuration;
+import com.blueshift.util.NotificationUtils;
 
 /**
  * Created by Rahul Raveendran
@@ -85,7 +86,7 @@ public class NotificationActivity extends AppCompatActivity {
             builder.create().show();
 
             // Tracking the notification display.
-            Blueshift.getInstance(mContext).trackNotificationView(mMessage);
+            NotificationUtils.invokePushDelivered(mContext, mMessage);
         } else {
             finish();
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -290,7 +290,7 @@ public class NotificationFactory {
             }
 
             // Tracking the notification display.
-            Blueshift.getInstance(context).trackNotificationView(message);
+            NotificationUtils.invokePushDelivered(context, message);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -207,7 +207,10 @@ public class BlueshiftUtils {
         if (clickElement != null) attr.put(BlueshiftConstants.KEY_CLICK_ELEMENT, clickElement);
 
         String clickUrl = readValue(BlueshiftConstants.KEY_CLICK_URL, inputMap);
-        if (clickUrl != null) attr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+        if (clickUrl != null) {
+            String encodedUrl = NetworkUtils.encodeUrlParam(clickUrl);
+            attr.put(BlueshiftConstants.KEY_CLICK_URL, encodedUrl);
+        }
 
         return attr;
     }

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -151,19 +151,6 @@ public class BlueshiftUtils {
                 && remoteMessage.getData().containsKey(Message.EXTRA_BSFT_MESSAGE_UUID);
     }
 
-    public static Map<String, Object> getMapFromPushMessage(Message message) {
-        if (message != null) {
-            Gson gson = new Gson();
-            String json = gson.toJson(message);
-            Type type = new TypeToken<Map<String, Object>>() {
-            }.getType();
-
-            return gson.fromJson(json, type);
-        }
-
-        return null;
-    }
-
     /**
      * This method is responsible for building the attributes for calling the track API.
      * <p>

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -7,9 +7,15 @@ import android.text.TextUtils;
 import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftLogger;
+import com.blueshift.inappmessage.InAppMessage;
 import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.Message;
 import com.google.firebase.messaging.RemoteMessage;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.Map;
 
 public class BlueshiftUtils {
     private static final String LOG_TAG = "Blueshift";
@@ -141,4 +147,22 @@ public class BlueshiftUtils {
                 && remoteMessage.getData() != null
                 && remoteMessage.getData().containsKey(Message.EXTRA_BSFT_MESSAGE_UUID);
     }
+
+    public static Map<String, Object> getMapFromPushMessage(Message message) {
+        if (message != null) {
+            Gson gson = new Gson();
+            String json = gson.toJson(message);
+            Type type = new TypeToken<Map<String, Object>>() {
+            }.getType();
+
+            return gson.fromJson(json, type);
+        }
+
+        return null;
+    }
+
+    public static Map<String, Object> getMapFromInAppMessage(InAppMessage inAppMessage) {
+        return null;
+    }
+
 }

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -6,8 +6,8 @@ import android.text.TextUtils;
 
 import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
-import com.blueshift.inappmessage.InAppMessage;
 import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.Message;
 import com.google.firebase.messaging.RemoteMessage;
@@ -157,6 +157,41 @@ public class BlueshiftUtils {
             }.getType();
 
             return gson.fromJson(json, type);
+        }
+
+        return null;
+    }
+
+    public static Map<String, String> buildTrackApiAttributesFromPayload(Map<String, Object> inputMap) {
+        Map<String, String> attr = new HashMap<>();
+
+        // campaign attributes
+        String mid = readValue(Message.EXTRA_BSFT_MESSAGE_UUID, inputMap);
+        if (mid != null) attr.put(BlueshiftConstants.KEY_MID, mid);
+
+        String eid = readValue(Message.EXTRA_BSFT_EXPERIMENT_UUID, inputMap);
+        if (eid != null) attr.put(BlueshiftConstants.KEY_EID, eid);
+
+        String uid = readValue(Message.EXTRA_BSFT_USER_UUID, inputMap);
+        if (uid != null) attr.put(BlueshiftConstants.KEY_UID, uid);
+
+        String txnid = readValue(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, inputMap);
+        if (txnid != null) attr.put(BlueshiftConstants.KEY_TXNID, txnid);
+
+        // click attributes (if present)
+        String clickElement = readValue(BlueshiftConstants.KEY_CLICK_ELEMENT, inputMap);
+        if (clickElement != null) attr.put(BlueshiftConstants.KEY_CLICK_ELEMENT, clickElement);
+
+        String clickUrl = readValue(BlueshiftConstants.KEY_CLICK_URL, inputMap);
+        if (clickUrl != null) attr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+
+        return attr;
+    }
+
+    private static String readValue(String key, Map<String, Object> inputMap) {
+        if (key != null && inputMap != null && inputMap.containsKey(key)) {
+            Object val = inputMap.get(key);
+            if (val != null) return String.valueOf(val);
         }
 
         return null;

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 public class BlueshiftUtils {
@@ -160,9 +161,4 @@ public class BlueshiftUtils {
 
         return null;
     }
-
-    public static Map<String, Object> getMapFromInAppMessage(InAppMessage inAppMessage) {
-        return null;
-    }
-
 }

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -1108,7 +1108,6 @@ public class InAppUtils {
             map.putAll(ex.toHasMap());
         }
 
-
         if (Blueshift.getBlueshiftInAppListener() != null) {
             Blueshift.getBlueshiftInAppListener().onInAppClicked(map);
         }

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -18,7 +18,9 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftExecutor;
+import com.blueshift.BlueshiftJSONObject;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.inappmessage.InAppConstants;
 import com.blueshift.inappmessage.InAppMessage;
@@ -41,6 +43,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class InAppUtils {
@@ -174,9 +177,9 @@ public class InAppUtils {
             try {
                 if (isDarkModeEnabled(context) && contentName != null) {
                     /*
-                    * This check is to safely fallback to the default config if the key
-                    * is absent in dark theme config.
-                    */
+                     * This check is to safely fallback to the default config if the key
+                     * is absent in dark theme config.
+                     */
                     JSONObject darkThemeConfig = inAppMessage.getContentStyleDark();
                     if (darkThemeConfig != null && darkThemeConfig.has(contentName)) {
                         return darkThemeConfig;
@@ -1074,5 +1077,42 @@ public class InAppUtils {
         }
 
         return epoch;
+    }
+
+    public static void invokeInAppDelivered(Context context, InAppMessage inAppMessage) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppDelivered(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageDelivered(inAppMessage);
+    }
+
+    public static void invokeInAppOpened(Context context, InAppMessage inAppMessage) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppOpened(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageView(inAppMessage);
+    }
+
+    public static void invokeInAppClicked(Context context, InAppMessage inAppMessage, JSONObject extras) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (map != null && extras != null) {
+            BlueshiftJSONObject ex = new BlueshiftJSONObject();
+            ex.putAll(extras);
+            map.putAll(ex.toHasMap());
+        }
+
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppClicked(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageClick(inAppMessage, extras);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -645,8 +645,8 @@ public class NotificationUtils {
      * @param message valid {@link Message} object
      */
     public static void invokePushDelivered(Context context, Message message) {
-        if (Blueshift.getBlueshiftPushListener() != null) {
-            Map<String, Object> attr = BlueshiftUtils.getMapFromPushMessage(message);
+        if (Blueshift.getBlueshiftPushListener() != null && message != null) {
+            Map<String, Object> attr = message.toMap();
             if (Blueshift.getBlueshiftPushListener() != null) {
                 Blueshift.getBlueshiftPushListener().onPushDelivered(attr);
             }
@@ -663,8 +663,8 @@ public class NotificationUtils {
      * @param message valid {@link Message} object
      */
     public static void invokePushClicked(Context context, Message message, String clickUrl) {
-        if (Blueshift.getBlueshiftPushListener() != null) {
-            Map<String, Object> attr = BlueshiftUtils.getMapFromPushMessage(message);
+        if (Blueshift.getBlueshiftPushListener() != null && message != null) {
+            Map<String, Object> attr = message.toMap();
             if (attr != null && clickUrl != null) {
                 attr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
             }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A class with helper methods to show custom notification.
@@ -552,12 +553,10 @@ public class NotificationUtils {
             Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
             if (message != null) {
                 try {
-                    HashMap<String, Object> clickAttr = new HashMap<>();
                     String deepLink = bundle.getString(RichPushConstants.EXTRA_DEEP_LINK_URL);
-                    clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, deepLink);
 
                     // mark 'click'
-                    Blueshift.getInstance(context).trackNotificationClick(message, clickAttr);
+                    NotificationUtils.invokePushClicked(context, message, deepLink);
 
                     Intent intent = null;
 
@@ -636,5 +635,47 @@ public class NotificationUtils {
                     "(context: " + context + ", intent: " + intent + ").");
             return false;
         }
+    }
+
+    /**
+     * This helper method allows the sdk to call the listener method (if provided) along with
+     * internal tracking method for push delivered.
+     *
+     * @param context valid {@link Context} object
+     * @param message valid {@link Message} object
+     */
+    public static void invokePushDelivered(Context context, Message message) {
+        if (Blueshift.getBlueshiftPushListener() != null) {
+            Map<String, Object> attr = BlueshiftUtils.getMapFromPushMessage(message);
+            if (Blueshift.getBlueshiftPushListener() != null) {
+                Blueshift.getBlueshiftPushListener().onPushDelivered(attr);
+            }
+        }
+
+        Blueshift.getInstance(context).trackNotificationView(message);
+    }
+
+    /**
+     * This helper method allows the sdk to call the listener method (if provided) along with
+     * internal tracking method for push click.
+     *
+     * @param context valid {@link Context} object
+     * @param message valid {@link Message} object
+     */
+    public static void invokePushClicked(Context context, Message message, String clickUrl) {
+        if (Blueshift.getBlueshiftPushListener() != null) {
+            Map<String, Object> attr = BlueshiftUtils.getMapFromPushMessage(message);
+            if (attr != null && clickUrl != null) {
+                attr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+            }
+
+            if (Blueshift.getBlueshiftPushListener() != null) {
+                Blueshift.getBlueshiftPushListener().onPushClicked(attr);
+            }
+        }
+
+        HashMap<String, Object> clickAttr = new HashMap<>();
+        if (clickUrl != null) clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+        Blueshift.getInstance(context).trackNotificationClick(message, clickAttr);
     }
 }


### PR DESCRIPTION
This change allows the host app to get callbacks when push and in-app tracking events like delivered, click and open occurs.