### PR TITLE
[MOBL-568] enabled app_open event throttling

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
@@ -22,6 +22,7 @@ public class BlueShiftPreference {
     private static final String PREF_FILE = "com.blueshift.sdk_preferences";
     private static final String PREF_KEY_DEVICE_ID = "blueshift_device_id";
     private static final String PREF_KEY_PUSH_ENABLED = "blueshift_push_enabled";
+    private static final String PREF_KEY_APP_OPEN_TRACKED_AT = "blueshift_app_open_tracked_at";
     private static final String PREF_FILE_EMAIL = "BsftEmailPrefFile";
 
     private static final String TAG = "BlueShiftPreference";
@@ -133,5 +134,23 @@ public class BlueShiftPreference {
 
     private static String getPreferenceFileName(@NonNull Context context, @NonNull String fileName) {
         return context.getPackageName() + "." + fileName;
+    }
+
+    public static long getAppOpenTrackedAt(Context context) {
+        long val = 0;
+
+        SharedPreferences preferences = getBlueshiftPreferences(context);
+        if (preferences != null) {
+            val = preferences.getLong(PREF_KEY_APP_OPEN_TRACKED_AT, 0);
+        }
+
+        return val;
+    }
+
+    public static void setAppOpenTrackedAt(Context context, long seconds) {
+        SharedPreferences preferences = getBlueshiftPreferences(context);
+        if (preferences != null) {
+            preferences.edit().putLong(PREF_KEY_APP_OPEN_TRACKED_AT, seconds).apply();
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -351,8 +351,12 @@ public class Blueshift {
         // schedule the bulk events dispatch
         BulkEventManager.scheduleBulkEventEnqueue(mContext);
         // fire an app open automatically if enabled
-        if (BlueshiftUtils.isAutomaticAppOpenFiringEnabled(mContext)) {
+        if (BlueshiftUtils.isAutomaticAppOpenFiringEnabled(mContext)
+                && BlueshiftUtils.canAutomaticAppOpenBeSentNow(mContext)) {
             trackAppOpen(false);
+            // mark the tracking time
+            long now = System.currentTimeMillis() / 1000;
+            BlueShiftPreference.setAppOpenTrackedAt(mContext, now);
         }
         // pull latest font from server
         InAppMessageIconFont.getInstance(mContext).updateFont(mContext);

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -49,6 +49,9 @@ public class Configuration {
 
     private boolean enableAutoAppOpen;
 
+    // This is the time interval between the app_open events fired by the SDK in seconds.
+    private long autoAppOpenInterval;
+
     private Blueshift.DeviceIdSource deviceIdSource;
     private String customDeviceId;
 
@@ -75,6 +78,10 @@ public class Configuration {
         // Job ids used in the SDK
         networkChangeListenerJobId = 901;
         bulkEventsJobId = 902;
+
+        // The default value is 0. When set to default, app_open
+        // event will be fired on each app restart.
+        autoAppOpenInterval = 0;
     }
 
     public int getAppIcon() {
@@ -212,6 +219,14 @@ public class Configuration {
 
     public void setBulkEventsJobId(int bulkEventsJobId) {
         this.bulkEventsJobId = bulkEventsJobId;
+    }
+
+    public long getAutoAppOpenInterval() {
+        return autoAppOpenInterval;
+    }
+
+    public void setAutoAppOpenInterval(long intervalInSeconds) {
+        this.autoAppOpenInterval = intervalInSeconds;
     }
 
     public boolean isAutoAppOpenFiringEnabled() {

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -79,9 +79,9 @@ public class Configuration {
         networkChangeListenerJobId = 901;
         bulkEventsJobId = 902;
 
-        // The default value is 0. When set to default, app_open
+        // The default value is 86400 seconds (24 hours). When set to 0, an app_open
         // event will be fired on each app restart.
-        autoAppOpenInterval = 0;
+        autoAppOpenInterval = 86400;
     }
 
     public int getAppIcon() {

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.text.TextUtils;
 
+import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.model.Configuration;
@@ -84,6 +85,25 @@ public class BlueshiftUtils {
         }
 
         return isEnabled;
+    }
+
+    public static boolean canAutomaticAppOpenBeSentNow(Context context) {
+        Configuration config = BlueshiftUtils.getConfiguration(context);
+        if (config != null && config.getAutoAppOpenInterval() > 0) {
+            long trackedAt = BlueShiftPreference.getAppOpenTrackedAt(context);
+            if (trackedAt > 0) {
+                long now = System.currentTimeMillis() / 1000;
+                long diff = now - trackedAt;
+                return diff > 0 && diff > config.getAutoAppOpenInterval();
+            } else {
+                BlueshiftLogger.d(LOG_TAG, "app_open default behavior (trackedAt == 0)");
+            }
+        } else {
+            BlueshiftLogger.d(LOG_TAG, "app_open default behavior (interval == 0)");
+        }
+
+        // the fall back value is set to true to keep the default behaviour
+        return true;
     }
 
     public static boolean isPushEnabled(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -94,7 +94,7 @@ public class BlueshiftUtils {
             if (trackedAt > 0) {
                 long now = System.currentTimeMillis() / 1000;
                 long diff = now - trackedAt;
-                return diff > 0 && diff > config.getAutoAppOpenInterval();
+                return diff > config.getAutoAppOpenInterval();
             } else {
                 BlueshiftLogger.d(LOG_TAG, "app_open default behavior (trackedAt == 0)");
             }


### PR DESCRIPTION
This change allows the user to throttle app_open events sent by the SDK by setting a time interval between two app_open events.