### PR TITLE
[MOBL-656] Fixed an issue with image cache for in-app modal

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -780,10 +780,17 @@ public class InAppManager {
                 // do nothing. cache is managed by WebView
             } else {
                 // modal with background
-                String bgImage = inAppMessage.getContentString(InAppConstants.BACKGROUND_IMAGE);
-                if (!TextUtils.isEmpty(bgImage)) {
-                    deleteCachedImage(context, bgImage);
-                }
+                // bg image: normal
+                String bgImgNormal = inAppMessage.getTemplateStyle() != null
+                        ? inAppMessage.getTemplateStyle().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgNormal)) deleteCachedImage(context, bgImgNormal);
+                // bg image: dark
+                String bgImgDark = inAppMessage.getTemplateStyleDark() != null
+                        ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgDark)) deleteCachedImage(context, bgImgDark);
+
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);
                 if (!TextUtils.isEmpty(bannerImage)) {
@@ -824,10 +831,17 @@ public class InAppManager {
                 // cache for modals and other templates
 
                 // modal with background
-                String bgImage = inAppMessage.getContentString(InAppConstants.BACKGROUND_IMAGE);
-                if (!TextUtils.isEmpty(bgImage)) {
-                    cacheImage(context, bgImage);
-                }
+                // bg image: normal
+                String bgImgNormal = inAppMessage.getTemplateStyle() != null
+                        ? inAppMessage.getTemplateStyle().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgNormal)) cacheImage(context, bgImgNormal);
+                // bg image: dark
+                String bgImgDark = inAppMessage.getTemplateStyleDark() != null
+                        ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgDark)) cacheImage(context, bgImgDark);
+
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);
                 if (!TextUtils.isEmpty(bannerImage)) {

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -789,7 +789,9 @@ public class InAppManager {
                 String bgImgDark = inAppMessage.getTemplateStyleDark() != null
                         ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
                         : null;
-                if (!TextUtils.isEmpty(bgImgDark)) deleteCachedImage(context, bgImgDark);
+                if (bgImgDark != null && !bgImgDark.isEmpty() && !bgImgDark.equals(bgImgNormal)) {
+                    deleteCachedImage(context, bgImgDark);
+                }
 
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);
@@ -840,7 +842,9 @@ public class InAppManager {
                 String bgImgDark = inAppMessage.getTemplateStyleDark() != null
                         ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
                         : null;
-                if (!TextUtils.isEmpty(bgImgDark)) cacheImage(context, bgImgDark);
+                if (bgImgDark != null && !bgImgDark.isEmpty() && !bgImgDark.equals(bgImgNormal)) {
+                    cacheImage(context, bgImgDark);
+                }
 
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);


### PR DESCRIPTION
The modal in-app's image cache was not working at times. The bug was identified and fixed in this change.