### PR TITLE
v3.1.9

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
@@ -22,6 +22,7 @@ public class BlueShiftPreference {
     private static final String PREF_FILE = "com.blueshift.sdk_preferences";
     private static final String PREF_KEY_DEVICE_ID = "blueshift_device_id";
     private static final String PREF_KEY_PUSH_ENABLED = "blueshift_push_enabled";
+    private static final String PREF_KEY_APP_OPEN_TRACKED_AT = "blueshift_app_open_tracked_at";
     private static final String PREF_FILE_EMAIL = "BsftEmailPrefFile";
 
     private static final String TAG = "BlueShiftPreference";
@@ -133,5 +134,23 @@ public class BlueShiftPreference {
 
     private static String getPreferenceFileName(@NonNull Context context, @NonNull String fileName) {
         return context.getPackageName() + "." + fileName;
+    }
+
+    public static long getAppOpenTrackedAt(Context context) {
+        long val = 0;
+
+        SharedPreferences preferences = getBlueshiftPreferences(context);
+        if (preferences != null) {
+            val = preferences.getLong(PREF_KEY_APP_OPEN_TRACKED_AT, 0);
+        }
+
+        return val;
+    }
+
+    public static void setAppOpenTrackedAt(Context context, long seconds) {
+        SharedPreferences preferences = getBlueshiftPreferences(context);
+        if (preferences != null) {
+            preferences.edit().putLong(PREF_KEY_APP_OPEN_TRACKED_AT, seconds).apply();
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -63,6 +63,8 @@ public class Blueshift {
     private Context mContext;
     private static Configuration mConfiguration;
     private static Blueshift instance = null;
+    private static BlueshiftPushListener blueshiftPushListener;
+    private static BlueshiftInAppListener blueshiftInAppListener;
 
     public enum DeviceIdSource {
         ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME, CUSTOM
@@ -86,6 +88,22 @@ public class Blueshift {
         }
 
         return instance;
+    }
+
+    public static BlueshiftPushListener getBlueshiftPushListener() {
+        return blueshiftPushListener;
+    }
+
+    public static BlueshiftInAppListener getBlueshiftInAppListener() {
+        return blueshiftInAppListener;
+    }
+
+    public static void setBlueshiftPushListener(BlueshiftPushListener pushListener) {
+        blueshiftPushListener = pushListener;
+    }
+
+    public static void setBlueshiftInAppListener(BlueshiftInAppListener inAppListener) {
+        blueshiftInAppListener = inAppListener;
     }
 
     public void registerForInAppMessages(Activity activity) {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -351,8 +351,12 @@ public class Blueshift {
         // schedule the bulk events dispatch
         BulkEventManager.scheduleBulkEventEnqueue(mContext);
         // fire an app open automatically if enabled
-        if (BlueshiftUtils.isAutomaticAppOpenFiringEnabled(mContext)) {
+        if (BlueshiftUtils.isAutomaticAppOpenFiringEnabled(mContext)
+                && BlueshiftUtils.canAutomaticAppOpenBeSentNow(mContext)) {
             trackAppOpen(false);
+            // mark the tracking time
+            long now = System.currentTimeMillis() / 1000;
+            BlueShiftPreference.setAppOpenTrackedAt(mContext, now);
         }
         // pull latest font from server
         InAppMessageIconFont.getInstance(mContext).updateFont(mContext);

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -581,6 +581,16 @@ public class Blueshift {
     }
 
     /**
+     * This method fires an identify event that fills in customer identifiers from user info and device info
+     *
+     * @param details           optional additional parameters
+     * @param canBatchThisEvent flag to indicate if this event can be sent in bulk event API
+     */
+    public void identifyUser(HashMap<String, Object> details, boolean canBatchThisEvent) {
+        trackEvent(BlueshiftConstants.EVENT_IDENTIFY, details, canBatchThisEvent);
+    }
+
+    /**
      * Helps trigger identify user api call using key 'retailer_customer_id'.
      *
      * @param customerId        if provided, replaces existing one (taken from UserInfo) inside request params.

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftInAppListener.java
@@ -1,0 +1,11 @@
+package com.blueshift;
+
+import java.util.Map;
+
+public interface BlueshiftInAppListener {
+    void onInAppDelivered(Map<String, Object> attributes);
+
+    void onInAppOpened(Map<String, Object> attributes);
+
+    void onInAppClicked(Map<String, Object> attributes);
+}

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftPushListener.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftPushListener.java
@@ -1,0 +1,9 @@
+package com.blueshift;
+
+import java.util.Map;
+
+public interface BlueshiftPushListener {
+    void onPushDelivered(Map<String, Object> attributes);
+
+    void onPushClicked(Map<String, Object> attributes);
+}

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -180,28 +180,14 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
         return false;
     }
 
-    public static void handlePushMessage(Context context, Intent intent) {
-        try {
-            if (context != null && intent != null) {
-                Bundle bundle = intent.getExtras();
-                if (bundle != null) {
-                    Map<String, String> map = new HashMap<>();
-                    for (String key : bundle.keySet()) {
-                        Object val = bundle.get(key);
-                        if (val != null) map.put(key, String.valueOf(val));
-                    }
 
-                    BlueshiftMessagingService service = new BlueshiftMessagingService();
-                    service.handleDataMessage(context, map);
-                }
-            } else {
-                BlueshiftLogger.e(LOG_TAG, "Could not handle push. Context is " + context + " and Intent is" + intent);
-            }
-        } catch (Exception e) {
-            BlueshiftLogger.e(LOG_TAG, e);
-        }
-    }
-
+    /**
+     * This method takes care of parsing the data payload to see if the push belongs to Blueshift
+     * and what action needs to be taken based on the payload content.
+     *
+     * @param context A valid {@link Context} object from the caller
+     * @param data    A valid data payload in the form of a {@link Map}
+     */
     private void handleDataMessage(Context context, Map<String, String> data) {
         if (data != null) {
             logPayload(data);
@@ -413,5 +399,57 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
         Blueshift
                 .getInstance(this)
                 .identifyUserByDeviceId(deviceId, null, false);
+    }
+
+    /**
+     * This method is required by the Blueshift-mParticle-Kit to do the push rendering when a push
+     * message is handed over to the kit by the mParticle SDK
+     *
+     * @param context {@link Context} object from the mParticle kit callback
+     * @param intent  {@link Intent} object from the mParticle kit callback
+     */
+    public static void handlePushMessage(Context context, Intent intent) {
+        try {
+            if (context != null && intent != null) {
+                Bundle bundle = intent.getExtras();
+                if (bundle != null) {
+                    Map<String, String> map = new HashMap<>();
+                    for (String key : bundle.keySet()) {
+                        Object val = bundle.get(key);
+                        if (val != null) map.put(key, String.valueOf(val));
+                    }
+
+                    BlueshiftMessagingService service = new BlueshiftMessagingService();
+                    service.handleDataMessage(context, map);
+                }
+            } else {
+                BlueshiftLogger.e(LOG_TAG, "Could not handle push. Context is " + context + " and Intent is" + intent);
+            }
+        } catch (Exception e) {
+            BlueshiftLogger.e(LOG_TAG, e);
+        }
+    }
+
+    /**
+     * Helper method for the host app to invoke the onMessageReceived method of the BlueshiftMessagingService class
+     *
+     * @param context       Valid {@link Context} object
+     * @param remoteMessage Valid {@link RemoteMessage} object
+     */
+    public static void handleMessageReceived(Context context, RemoteMessage remoteMessage) {
+        if (context != null && remoteMessage != null) {
+            new BlueshiftMessagingService().handleDataMessage(context, remoteMessage.getData());
+        }
+    }
+
+    /**
+     * Helper method for the host app to invoke the onNewToken method of the BlueshiftMessagingService class
+     *
+     * @param newToken Valid new token provided by FCM
+     */
+    public static void handleNewToken(String newToken) {
+        if (newToken != null) {
+            new BlueshiftMessagingService().onNewToken(newToken);
+        }
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -780,10 +780,19 @@ public class InAppManager {
                 // do nothing. cache is managed by WebView
             } else {
                 // modal with background
-                String bgImage = inAppMessage.getContentString(InAppConstants.BACKGROUND_IMAGE);
-                if (!TextUtils.isEmpty(bgImage)) {
-                    deleteCachedImage(context, bgImage);
+                // bg image: normal
+                String bgImgNormal = inAppMessage.getTemplateStyle() != null
+                        ? inAppMessage.getTemplateStyle().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgNormal)) deleteCachedImage(context, bgImgNormal);
+                // bg image: dark
+                String bgImgDark = inAppMessage.getTemplateStyleDark() != null
+                        ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (bgImgDark != null && !bgImgDark.isEmpty() && !bgImgDark.equals(bgImgNormal)) {
+                    deleteCachedImage(context, bgImgDark);
                 }
+
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);
                 if (!TextUtils.isEmpty(bannerImage)) {
@@ -824,10 +833,19 @@ public class InAppManager {
                 // cache for modals and other templates
 
                 // modal with background
-                String bgImage = inAppMessage.getContentString(InAppConstants.BACKGROUND_IMAGE);
-                if (!TextUtils.isEmpty(bgImage)) {
-                    cacheImage(context, bgImage);
+                // bg image: normal
+                String bgImgNormal = inAppMessage.getTemplateStyle() != null
+                        ? inAppMessage.getTemplateStyle().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (!TextUtils.isEmpty(bgImgNormal)) cacheImage(context, bgImgNormal);
+                // bg image: dark
+                String bgImgDark = inAppMessage.getTemplateStyleDark() != null
+                        ? inAppMessage.getTemplateStyleDark().optString(InAppConstants.BACKGROUND_IMAGE)
+                        : null;
+                if (bgImgDark != null && !bgImgDark.isEmpty() && !bgImgDark.equals(bgImgNormal)) {
+                    cacheImage(context, bgImgDark);
                 }
+
                 // modal with banner
                 String bannerImage = inAppMessage.getContentString(InAppConstants.BANNER);
                 if (!TextUtils.isEmpty(bannerImage)) {

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -298,7 +298,7 @@ public class InAppManager {
             BlueshiftLogger.d(LOG_TAG, "In-app message received. Message UUID: " + (inAppMessage != null ? inAppMessage.getMessageUuid() : null));
 
             if (inAppMessage != null) {
-                Blueshift.getInstance(context).trackInAppMessageDelivered(inAppMessage);
+                InAppUtils.invokeInAppDelivered(context, inAppMessage);
 
                 if (!inAppMessage.isExpired()) {
                     boolean inserted = InAppMessageStore.getInstance(context).insert(inAppMessage);
@@ -584,7 +584,7 @@ public class InAppManager {
         // dismiss the dialog and cleanup memory
         dismissAndCleanupDialog();
         // log the click event
-        Blueshift.getInstance(appContext).trackInAppMessageClick(inAppMessage, extras);
+        InAppUtils.invokeInAppClicked(appContext, inAppMessage, extras);
     }
 
     private static void invokeOnInAppViewed(InAppMessage inAppMessage) {
@@ -594,7 +594,7 @@ public class InAppManager {
         Context appContext = mActivity != null ? mActivity.getApplicationContext() : null;
         if (appContext != null) {
             // send stats
-            Blueshift.getInstance(appContext).trackInAppMessageView(inAppMessage);
+            InAppUtils.invokeInAppOpened(appContext, inAppMessage);
             // update with displayed at timing
             inAppMessage.setDisplayedAt(System.currentTimeMillis());
             InAppMessageStore.getInstance(appContext).update(inAppMessage);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessage.java
@@ -44,6 +44,30 @@ public class InAppMessage extends BlueshiftBaseSQLiteModel {
     private String transaction_uuid;
     private String timestamp;
 
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(InAppConstants.TYPE, type);
+        map.put(InAppConstants.EXPIRES_AT, expires_at);
+        map.put(InAppConstants.TRIGGER, trigger);
+        map.put(InAppConstants.DISPLAY_ON, display_on);
+        map.put(InAppConstants.TEMPLATE_STYLE, template_style);
+        map.put(InAppConstants.TEMPLATE_STYLE_DARK, template_style_dark);
+        map.put(InAppConstants.CONTENT_STYLE, content_style);
+        map.put(InAppConstants.CONTENT_STYLE_DARK, content_style_dark);
+        map.put(InAppConstants.CONTENT, content);
+        map.put(InAppConstants.EXTRAS, extras);
+
+        map.put(Message.EXTRA_BSFT_MESSAGE_UUID, message_uuid);
+        map.put(Message.EXTRA_BSFT_EXPERIMENT_UUID, experiment_uuid);
+        map.put(Message.EXTRA_BSFT_USER_UUID, user_uuid);
+        map.put(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, transaction_uuid);
+
+        map.put(BlueshiftConstants.KEY_TIMESTAMP, timestamp);
+
+        return map;
+    }
+
     public static InAppMessage getInstance(JSONObject jsonObject) {
         try {
             String json = jsonObject.optString(InAppMessage.EXTRA_IN_APP);

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageView.java
@@ -185,9 +185,7 @@ public abstract class InAppMessageView extends RelativeLayout {
                 JSONObject statsParams = getClickStatsJSONObject(element);
                 String androidLink = actionJson.optString(InAppConstants.ANDROID_LINK);
                 if (!TextUtils.isEmpty(androidLink)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(androidLink));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, androidLink);
                 }
 
                 if (InAppManager.getActionCallback() != null) {

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageViewHTML.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageViewHTML.java
@@ -63,9 +63,7 @@ public class InAppMessageViewHTML extends InAppMessageView {
             JSONObject statsParams = getClickStatsJSONObject(null);
             try {
                 if (!TextUtils.isEmpty(link)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(link));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, link);
                 }
             } catch (JSONException ignore) {
             }
@@ -97,9 +95,7 @@ public class InAppMessageViewHTML extends InAppMessageView {
             try {
                 String link = uri.toString();
                 if (!TextUtils.isEmpty(link)) {
-                    statsParams.putOpt(
-                            BlueshiftConstants.KEY_CLICK_URL,
-                            NetworkUtils.encodeUrlParam(link));
+                    statsParams.putOpt(BlueshiftConstants.KEY_CLICK_URL, link);
                 }
             } catch (JSONException ignored) {
             }

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -49,6 +49,9 @@ public class Configuration {
 
     private boolean enableAutoAppOpen;
 
+    // This is the time interval between the app_open events fired by the SDK in seconds.
+    private long autoAppOpenInterval;
+
     private Blueshift.DeviceIdSource deviceIdSource;
     private String customDeviceId;
 
@@ -75,6 +78,10 @@ public class Configuration {
         // Job ids used in the SDK
         networkChangeListenerJobId = 901;
         bulkEventsJobId = 902;
+
+        // The default value is 86400 seconds (24 hours). When set to 0, an app_open
+        // event will be fired on each app restart.
+        autoAppOpenInterval = 86400;
     }
 
     public int getAppIcon() {
@@ -212,6 +219,14 @@ public class Configuration {
 
     public void setBulkEventsJobId(int bulkEventsJobId) {
         this.bulkEventsJobId = bulkEventsJobId;
+    }
+
+    public long getAutoAppOpenInterval() {
+        return autoAppOpenInterval;
+    }
+
+    public void setAutoAppOpenInterval(long intervalInSeconds) {
+        this.autoAppOpenInterval = intervalInSeconds;
     }
 
     public boolean isAutoAppOpenFiringEnabled() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -89,8 +89,7 @@ class CustomNotificationFactory {
                     manager.notify(notificationId, notification);
                 }
 
-                // Tracking the notification display.
-                Blueshift.getInstance(context).trackNotificationView(message);
+                NotificationUtils.invokePushDelivered(context, message);
             }
         }
     }
@@ -142,7 +141,7 @@ class CustomNotificationFactory {
 
                 if (!isUpdating) {
                     // Tracking the notification display for the first time
-                    Blueshift.getInstance(context).trackNotificationView(message);
+                    NotificationUtils.invokePushDelivered(context, message);
                 }
             }
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -5,11 +5,12 @@ import android.text.TextUtils;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 18/2/15 @ 12:20 PM
- *         https://github.com/rahulrvp
+ * Created on 18/2/15 @ 12:20 PM
+ * https://github.com/rahulrvp
  */
 public class Message implements Serializable {
     public static final String EXTRA_MESSAGE = "message";
@@ -29,7 +30,7 @@ public class Message implements Serializable {
     private String bsft_transaction_uuid; // present only with transactional campaign
     private Boolean bsft_seed_list_send; // test messages sent to seed list of users will have this
 
-    /**
+    /*
      * The following variables are used for parsing the 'message' payload.
      * They are the values used for creating the notification.
      */
@@ -164,6 +165,41 @@ public class Message implements Serializable {
     private String notification_channel_id;
     private String notification_channel_name;
     private String notification_channel_description;
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put(Message.EXTRA_BSFT_MESSAGE_UUID, bsft_message_uuid);
+        map.put(Message.EXTRA_BSFT_EXPERIMENT_UUID, bsft_experiment_uuid);
+        map.put(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, bsft_transaction_uuid);
+        map.put(Message.EXTRA_BSFT_USER_UUID, bsft_user_uuid);
+        map.put(Message.EXTRA_BSFT_SEED_LIST_SEND, bsft_seed_list_send);
+
+        map.put("notification_type", notification_type);
+        map.put("category", category);
+        map.put("content_title", content_title);
+        map.put("content_text", content_text);
+        map.put("content_sub_text", content_sub_text);
+        map.put("big_content_title", big_content_title);
+        map.put("big_content_summary_text", big_content_summary_text);
+        map.put("image_url", image_url);
+        map.put("carousel_elements", carousel_elements);
+        map.put("deep_link_url", deep_link_url);
+        map.put("url", url);
+        map.put("product_id", product_id);
+        map.put("sku", sku);
+        map.put("mrp", mrp);
+        map.put("price", price);
+        map.put("data", data);
+        map.put("notifications", notifications);
+        map.put("timestamp_to_display", timestamp_to_display);
+        map.put("timestamp_to_expire_display", timestamp_to_expire_display);
+        map.put("notification_channel_id", notification_channel_id);
+        map.put("notification_channel_name", notification_channel_name);
+        map.put("notification_channel_description", notification_channel_description);
+
+        return map;
+    }
 
     /**
      * The following are the get / set methods for the above declared variables.

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -12,6 +12,7 @@ import android.view.Window;
 import com.blueshift.Blueshift;
 import com.blueshift.R;
 import com.blueshift.model.Configuration;
+import com.blueshift.util.NotificationUtils;
 
 /**
  * Created by Rahul Raveendran
@@ -85,7 +86,7 @@ public class NotificationActivity extends AppCompatActivity {
             builder.create().show();
 
             // Tracking the notification display.
-            Blueshift.getInstance(mContext).trackNotificationView(mMessage);
+            NotificationUtils.invokePushDelivered(mContext, mMessage);
         } else {
             finish();
         }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -18,7 +18,11 @@ import com.blueshift.model.Configuration;
  * <p>
  * This activity is responsible for creating dialog notifications.
  * Currently supports two types of dialogues.
+ *
+ * @deprecated This Activity is deprecated as the notification_type "alert" is deprecated.
+ * This class will be removed from the project later in time.
  */
+@Deprecated
 public class NotificationActivity extends AppCompatActivity {
 
     private Context mContext;

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -290,7 +290,7 @@ public class NotificationFactory {
             }
 
             // Tracking the notification display.
-            Blueshift.getInstance(context).trackNotificationView(message);
+            NotificationUtils.invokePushDelivered(context, message);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -33,8 +33,8 @@ import java.util.Random;
 
 /**
  * @author Rahul Raveendran V P
- *         Created on 18/2/15 @ 12:22 PM
- *         https://github.com/rahulrvp
+ * Created on 18/2/15 @ 12:22 PM
+ * https://github.com/rahulrvp
  */
 public class NotificationFactory {
     private final static String LOG_TAG = NotificationFactory.class.getSimpleName();
@@ -74,6 +74,16 @@ public class NotificationFactory {
         }
     }
 
+    /**
+     * This method is responsible for showing a popup dialog when receiving a push message with
+     * notification_type "alert".
+     *
+     * @param context context object
+     * @param message message object
+     * @deprecated This method is deprecated because Blueshift has deprecated the notification type
+     * "alert" that displays popup dialogs on receiving the push. Use in-app messages instead.
+     */
+    @Deprecated
     private static void buildAndShowAlertDialog(final Context context, final Message message) {
         if (context != null && message != null) {
             final Handler handler = BlueshiftExecutor.getInstance().getMyHandler();
@@ -98,6 +108,7 @@ public class NotificationFactory {
         }
     }
 
+    @Deprecated
     private static void launchNotificationActivity(Context context, Message message, boolean appIsInForeground) {
         if (context != null && message != null) {
             Intent notificationIntent = new Intent(context, NotificationActivity.class);

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.text.TextUtils;
 
+import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.model.Configuration;
@@ -84,6 +85,25 @@ public class BlueshiftUtils {
         }
 
         return isEnabled;
+    }
+
+    public static boolean canAutomaticAppOpenBeSentNow(Context context) {
+        Configuration config = BlueshiftUtils.getConfiguration(context);
+        if (config != null && config.getAutoAppOpenInterval() > 0) {
+            long trackedAt = BlueShiftPreference.getAppOpenTrackedAt(context);
+            if (trackedAt > 0) {
+                long now = System.currentTimeMillis() / 1000;
+                long diff = now - trackedAt;
+                return diff > config.getAutoAppOpenInterval();
+            } else {
+                BlueshiftLogger.d(LOG_TAG, "app_open default behavior (trackedAt == 0)");
+            }
+        } else {
+            BlueshiftLogger.d(LOG_TAG, "app_open default behavior (interval == 0)");
+        }
+
+        // the fall back value is set to true to keep the default behaviour
+        return true;
     }
 
     public static boolean isPushEnabled(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -2,14 +2,23 @@ package com.blueshift.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
 
 import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
+import com.blueshift.BuildConfig;
 import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.Message;
 import com.google.firebase.messaging.RemoteMessage;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BlueshiftUtils {
     private static final String LOG_TAG = "Blueshift";
@@ -140,5 +149,65 @@ public class BlueshiftUtils {
         return remoteMessage != null
                 && remoteMessage.getData() != null
                 && remoteMessage.getData().containsKey(Message.EXTRA_BSFT_MESSAGE_UUID);
+    }
+
+    /**
+     * This method is responsible for building the attributes for calling the track API.
+     * <p>
+     * <b>Note:</b>
+     * This method must be called from a non UI thread if the deviceIdSource is set to ADVERTISING_ID.
+     *
+     * @param inputMap in-app or push payload with additional tracking info.
+     * @param context  valid context object.
+     * @return {@link Map} of attributes with appropriate keys required to call the track API.
+     */
+    @WorkerThread
+    public static Map<String, String> buildTrackApiAttributesFromPayload(Map<String, Object> inputMap, Context context) {
+        Map<String, String> attr = new HashMap<>();
+
+        // campaign attributes
+        String mid = readValue(Message.EXTRA_BSFT_MESSAGE_UUID, inputMap);
+        if (mid != null) attr.put(BlueshiftConstants.KEY_MID, mid);
+
+        String eid = readValue(Message.EXTRA_BSFT_EXPERIMENT_UUID, inputMap);
+        if (eid != null) attr.put(BlueshiftConstants.KEY_EID, eid);
+
+        String uid = readValue(Message.EXTRA_BSFT_USER_UUID, inputMap);
+        if (uid != null) attr.put(BlueshiftConstants.KEY_UID, uid);
+
+        String txnid = readValue(Message.EXTRA_BSFT_TRANSACTIONAL_UUID, inputMap);
+        if (txnid != null) attr.put(BlueshiftConstants.KEY_TXNID, txnid);
+
+        // app name
+        if (context != null) attr.put(BlueshiftConstants.KEY_APP_NAME, context.getPackageName());
+
+        // device id
+        String deviceId = DeviceUtils.getDeviceId(context);
+        if (deviceId != null) attr.put(BlueshiftConstants.KEY_DEVICE_IDENTIFIER, deviceId);
+
+        // sdk version & timestamp
+        attr.put(BlueshiftConstants.KEY_SDK_VERSION, BuildConfig.SDK_VERSION);
+        attr.put(BlueshiftConstants.KEY_TIMESTAMP, CommonUtils.getCurrentUtcTimestamp());
+
+        // click attributes (if present)
+        String clickElement = readValue(BlueshiftConstants.KEY_CLICK_ELEMENT, inputMap);
+        if (clickElement != null) attr.put(BlueshiftConstants.KEY_CLICK_ELEMENT, clickElement);
+
+        String clickUrl = readValue(BlueshiftConstants.KEY_CLICK_URL, inputMap);
+        if (clickUrl != null) {
+            String encodedUrl = NetworkUtils.encodeUrlParam(clickUrl);
+            attr.put(BlueshiftConstants.KEY_CLICK_URL, encodedUrl);
+        }
+
+        return attr;
+    }
+
+    private static String readValue(String key, Map<String, Object> inputMap) {
+        if (key != null && inputMap != null && inputMap.containsKey(key)) {
+            Object val = inputMap.get(key);
+            if (val != null) return String.valueOf(val);
+        }
+
+        return null;
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -18,7 +18,9 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftExecutor;
+import com.blueshift.BlueshiftJSONObject;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.inappmessage.InAppConstants;
 import com.blueshift.inappmessage.InAppMessage;
@@ -41,6 +43,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class InAppUtils {
@@ -174,9 +177,9 @@ public class InAppUtils {
             try {
                 if (isDarkModeEnabled(context) && contentName != null) {
                     /*
-                    * This check is to safely fallback to the default config if the key
-                    * is absent in dark theme config.
-                    */
+                     * This check is to safely fallback to the default config if the key
+                     * is absent in dark theme config.
+                     */
                     JSONObject darkThemeConfig = inAppMessage.getContentStyleDark();
                     if (darkThemeConfig != null && darkThemeConfig.has(contentName)) {
                         return darkThemeConfig;
@@ -1074,5 +1077,41 @@ public class InAppUtils {
         }
 
         return epoch;
+    }
+
+    public static void invokeInAppDelivered(Context context, InAppMessage inAppMessage) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppDelivered(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageDelivered(inAppMessage);
+    }
+
+    public static void invokeInAppOpened(Context context, InAppMessage inAppMessage) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppOpened(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageView(inAppMessage);
+    }
+
+    public static void invokeInAppClicked(Context context, InAppMessage inAppMessage, JSONObject extras) {
+        Map<String, Object> map = inAppMessage != null ? inAppMessage.toMap() : null;
+
+        if (map != null && extras != null) {
+            BlueshiftJSONObject ex = new BlueshiftJSONObject();
+            ex.putAll(extras);
+            map.putAll(ex.toHasMap());
+        }
+
+        if (Blueshift.getBlueshiftInAppListener() != null) {
+            Blueshift.getBlueshiftInAppListener().onInAppClicked(map);
+        }
+
+        Blueshift.getInstance(context).trackInAppMessageClick(inAppMessage, extras);
     }
 }

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A class with helper methods to show custom notification.
@@ -552,12 +553,10 @@ public class NotificationUtils {
             Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
             if (message != null) {
                 try {
-                    HashMap<String, Object> clickAttr = new HashMap<>();
                     String deepLink = bundle.getString(RichPushConstants.EXTRA_DEEP_LINK_URL);
-                    clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, deepLink);
 
                     // mark 'click'
-                    Blueshift.getInstance(context).trackNotificationClick(message, clickAttr);
+                    NotificationUtils.invokePushClicked(context, message, deepLink);
 
                     Intent intent = null;
 
@@ -636,5 +635,47 @@ public class NotificationUtils {
                     "(context: " + context + ", intent: " + intent + ").");
             return false;
         }
+    }
+
+    /**
+     * This helper method allows the sdk to call the listener method (if provided) along with
+     * internal tracking method for push delivered.
+     *
+     * @param context valid {@link Context} object
+     * @param message valid {@link Message} object
+     */
+    public static void invokePushDelivered(Context context, Message message) {
+        if (Blueshift.getBlueshiftPushListener() != null && message != null) {
+            Map<String, Object> attr = message.toMap();
+            if (Blueshift.getBlueshiftPushListener() != null) {
+                Blueshift.getBlueshiftPushListener().onPushDelivered(attr);
+            }
+        }
+
+        Blueshift.getInstance(context).trackNotificationView(message);
+    }
+
+    /**
+     * This helper method allows the sdk to call the listener method (if provided) along with
+     * internal tracking method for push click.
+     *
+     * @param context valid {@link Context} object
+     * @param message valid {@link Message} object
+     */
+    public static void invokePushClicked(Context context, Message message, String clickUrl) {
+        if (Blueshift.getBlueshiftPushListener() != null && message != null) {
+            Map<String, Object> attr = message.toMap();
+            if (attr != null && clickUrl != null) {
+                attr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+            }
+
+            if (Blueshift.getBlueshiftPushListener() != null) {
+                Blueshift.getBlueshiftPushListener().onPushClicked(attr);
+            }
+        }
+
+        HashMap<String, Object> clickAttr = new HashMap<>();
+        if (clickUrl != null) clickAttr.put(BlueshiftConstants.KEY_CLICK_URL, clickUrl);
+        Blueshift.getInstance(context).trackNotificationClick(message, clickAttr);
     }
 }


### PR DESCRIPTION
# Changelist
- SDK will now throttle the `app_open` events based on given time interval. The default behavior is to fire one `app_open` in 24 hours. To change the time interval set `config.autoAppOpenInterval` value in seconds.
- Added callbacks for in-app and push tracking events (`delivered`, `open` and `click`).
- Deprecated "alert" notification type on the SDK side. The template is already removed from the dashboard.
- Improved image cache for in-app modal background images to support screen orientation changes.
- Added `identifyUser()` method that can take customer identifiers from `UserInfo` and fire the identify event.