### PR TITLE
v2.1.10

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -92,11 +92,39 @@ public class Blueshift {
         return instance;
     }
 
-    public static void setTrackingEnabled(Context context, boolean enabled) {
-        BlueshiftAppPreferences.getInstance(context).setEnableTracking(context, enabled);
+    /**
+     * Enable/disable the event tracking done by the SDK. By default, the tracking is enabled.
+     * <p>
+     * When disabled, no new events will be added to the queue. Also, any unsent events
+     * (batched and realtime) will be deleted from the SDK's database immediately.
+     *
+     * @param context   valid context object
+     * @param isEnabled the value that decides if the SDK should be enabled (true) or disabled (false)
+     * @since 3.1.10
+     */
+    public static void setTrackingEnabled(Context context, boolean isEnabled) {
+        // The events should be removed when the SDK is disabled. This is the default behavior.
+        boolean shouldRemoveEvents = !isEnabled;
 
-        // Delete events from all tables when tracking is disabled.
-        if (!enabled) {
+        setTrackingEnabled(context, isEnabled, shouldRemoveEvents);
+    }
+
+
+    /**
+     * Enable/disable the event tracking done by the SDK. By default, the tracking is enabled.
+     *
+     * @param context            valid context object
+     * @param isEnabled          the value that decides if the SDK should be enabled (true) or disabled (false).
+     * @param shouldRemoveEvents the value that decided if the SDK should remove unsent events from it's database.
+     * @since 3.1.10
+     */
+    public static void setTrackingEnabled(Context context, boolean isEnabled, boolean shouldRemoveEvents) {
+        BlueshiftLogger.d(LOG_TAG, "Event tracking is " + (isEnabled ? "enabled." : "disabled.")
+                + " Unsent events will" + (shouldRemoveEvents ? " " : " not ") + "be removed.");
+
+        BlueshiftAppPreferences.getInstance(context).setEnableTracking(context, isEnabled);
+
+        if (shouldRemoveEvents) {
             // Request queue table. This include both realtime and batched events.
             RequestQueueTable.getInstance(context).deleteAllAsync();
             // Events table. These are events waiting to get batched.

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -126,8 +126,12 @@ public class Blueshift {
         InAppManager.setActionCallback(callback);
     }
 
-    public void handleInAppMessageApiResponse(Context context, String response) {
-        InAppManager.handleInAppMessageApiResponse(context, response);
+    public void handleInAppMessageAPIResponse(Context context, String response) {
+        InAppManager.handleInAppMessageAPIResponse(context, response);
+    }
+
+    public JSONObject getInAppMessageAPIRequestPayload(Context context) {
+        return InAppManager.generateInAppMessageAPIRequestPayload(context);
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -126,6 +126,10 @@ public class Blueshift {
         InAppManager.setActionCallback(callback);
     }
 
+    public void handleInAppMessageApiResponse(Context context, String response) {
+        InAppManager.handleInAppMessageApiResponse(context, response);
+    }
+
     /**
      * Reset uuid which is being sent as device_id for this app
      */

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -16,6 +16,7 @@ import android.text.TextUtils;
 import com.blueshift.batch.BulkEventManager;
 import com.blueshift.batch.Event;
 import com.blueshift.batch.EventsTable;
+import com.blueshift.batch.FailedEventsTable;
 import com.blueshift.httpmanager.Method;
 import com.blueshift.httpmanager.Request;
 import com.blueshift.inappmessage.InAppActionCallback;
@@ -29,6 +30,7 @@ import com.blueshift.model.Product;
 import com.blueshift.model.Subscription;
 import com.blueshift.model.UserInfo;
 import com.blueshift.request_queue.RequestQueue;
+import com.blueshift.request_queue.RequestQueueTable;
 import com.blueshift.rich_push.Message;
 import com.blueshift.type.SubscriptionState;
 import com.blueshift.util.BlueshiftUtils;
@@ -93,7 +95,15 @@ public class Blueshift {
     public static void setTrackingEnabled(Context context, boolean enabled) {
         BlueshiftAppPreferences.getInstance(context).setEnableTracking(context, enabled);
 
-        // TODO: 25/02/21 Wipe data async
+        // Delete events from all tables when tracking is disabled.
+        if (!enabled) {
+            // Request queue table. This include both realtime and batched events.
+            RequestQueueTable.getInstance(context).deleteAllAsync();
+            // Events table. These are events waiting to get batched.
+            EventsTable.getInstance(context).deleteAllAsync();
+            // Failed events table. These will also get batched periodically.
+            FailedEventsTable.getInstance(context).deleteAllAsync();
+        }
     }
 
     public static boolean isTrackingEnabled(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -90,6 +90,16 @@ public class Blueshift {
         return instance;
     }
 
+    public static void setTrackingEnabled(Context context, boolean enabled) {
+        BlueshiftAppPreferences.getInstance(context).setEnableTracking(context, enabled);
+
+        // TODO: 25/02/21 Wipe data async
+    }
+
+    public static boolean isTrackingEnabled(Context context) {
+        return BlueshiftAppPreferences.getInstance(context).getEnableTracking();
+    }
+
     public static BlueshiftPushListener getBlueshiftPushListener() {
         return blueshiftPushListener;
     }
@@ -566,19 +576,23 @@ public class Blueshift {
      */
     @SuppressWarnings("WeakerAccess")
     public void trackEvent(@NonNull final String eventName, final HashMap<String, Object> params, final boolean canBatchThisEvent) {
-        BlueshiftExecutor.getInstance().runOnDiskIOThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            boolean tracked = sendEvent(eventName, params, canBatchThisEvent);
-                            BlueshiftLogger.d(LOG_TAG, "Event tracking { name: " + eventName + ", status: " + tracked + " }");
-                        } catch (Exception e) {
-                            BlueshiftLogger.e(LOG_TAG, e);
+        if (Blueshift.isTrackingEnabled(mContext)) {
+            BlueshiftExecutor.getInstance().runOnDiskIOThread(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                boolean tracked = sendEvent(eventName, params, canBatchThisEvent);
+                                BlueshiftLogger.d(LOG_TAG, "Event tracking { name: " + eventName + ", status: " + tracked + " }");
+                            } catch (Exception e) {
+                                BlueshiftLogger.e(LOG_TAG, e);
+                            }
                         }
                     }
-                }
-        );
+            );
+        } else {
+            BlueshiftLogger.i(LOG_TAG, "Blueshift SDK's event tracking is disabled. Dropping event: " + eventName);
+        }
     }
 
     /**
@@ -1293,15 +1307,19 @@ public class Blueshift {
     private void trackCampaignEventAsync(final String eventName,
                                          final HashMap<String, Object> campaignAttr,
                                          final HashMap<String, Object> extraAttr) {
-        BlueshiftExecutor.getInstance().runOnDiskIOThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        boolean tracked = sendNotificationEvent(eventName, campaignAttr, extraAttr);
-                        BlueshiftLogger.d(LOG_TAG, "Event tracking { name: " + eventName + ", status: " + tracked + " }");
+        if (Blueshift.isTrackingEnabled(mContext)) {
+            BlueshiftExecutor.getInstance().runOnDiskIOThread(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            boolean tracked = sendNotificationEvent(eventName, campaignAttr, extraAttr);
+                            BlueshiftLogger.d(LOG_TAG, "Event tracking { name: " + eventName + ", status: " + tracked + " }");
+                        }
                     }
-                }
-        );
+            );
+        } else {
+            BlueshiftLogger.i(LOG_TAG, "Blueshift SDK's event tracking is disabled. Dropping event: " + eventName);
+        }
     }
 
     private void updateAndroidAdId(final Context context) {

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAppPreferences.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAppPreferences.java
@@ -13,6 +13,7 @@ public class BlueshiftAppPreferences extends BlueshiftJSONObject {
     private static final String PREF_KEY = "bsft_app_preferences_json";
 
     private static final String KEY_ENABLE_PUSH = "bsft_enable_push";
+    private static final String KEY_ENABLE_TRACKING = "bsft_enable_tracking";
 
     private static final BlueshiftAppPreferences instance = new BlueshiftAppPreferences();
 
@@ -78,6 +79,32 @@ public class BlueshiftAppPreferences extends BlueshiftJSONObject {
             }
 
             // default true
+            return true;
+        }
+    }
+
+    void setEnableTracking(Context context, boolean enable) {
+        synchronized (instance) {
+            try {
+                instance.put(KEY_ENABLE_TRACKING, enable);
+                save(context);
+            } catch (Exception e) {
+                BlueshiftLogger.e(TAG, e);
+            }
+        }
+    }
+
+    boolean getEnableTracking() {
+        synchronized (instance) {
+            try {
+                if (instance.has(KEY_ENABLE_TRACKING)) {
+                    return instance.getBoolean(KEY_ENABLE_TRACKING);
+                }
+            } catch (Exception e) {
+                BlueshiftLogger.e(TAG, e);
+            }
+
+            // SDK sends events by default.
             return true;
         }
     }

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftHttpManager.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftHttpManager.java
@@ -1,6 +1,5 @@
 package com.blueshift;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -83,12 +82,13 @@ public class BlueshiftHttpManager {
     private void logRequest(BlueshiftHttpRequest request) {
         if (request != null) {
             try {
-                JSONObject logger = new JSONObject();
-                logger.putOpt("url", request.getUrlWithParams());
-                logger.putOpt("method", request.getMethod());
-                logger.putOpt("body", request.getReqBodyJson());
+                String log = "{" +
+                        "\"api\":\"" + request.getUrlWithParams() + "\"," +
+                        "\"method\":\"" + request.getMethod() + "\"," +
+                        "\"body\":" + request.getReqBodyJson() +
+                        "}";
 
-                BlueshiftLogger.i(TAG, logger.toString());
+                BlueshiftLogger.i(TAG, log);
             } catch (Exception e) {
                 BlueshiftLogger.e(TAG, e);
             }

--- a/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.RequiresApi;
 
+import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.httpmanager.Method;
@@ -124,6 +125,11 @@ public class BulkEventManager {
     }
 
     public static void enqueueBulkEvents(Context context) {
+        if (!Blueshift.isTrackingEnabled(context)) {
+            BlueshiftLogger.i(LOG_TAG, "Blueshift SDK's event tracking is disabled. Skipping bulk event enqueueing.");
+            return;
+        }
+
         ArrayList<HashMap<String, Object>> tempBulkEventsApiParams = new ArrayList<>();
 
         int failedEventsCount;

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -171,7 +171,7 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
         try {
             if (intent != null) {
                 Bundle bundle = intent.getExtras();
-                return  (bundle != null && bundle.keySet() != null && bundle.keySet().contains("message"));
+                return (bundle != null && bundle.keySet() != null && bundle.keySet().contains("message"));
             }
         } catch (Exception e) {
             BlueshiftLogger.e(LOG_TAG, e);
@@ -269,7 +269,10 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
             InAppMessage inAppMessage = InAppMessage.getInstance(data);
             if (inAppMessage != null) {
                 InAppManager.onInAppMessageReceived(context, inAppMessage);
-                InAppMessageStore.getInstance(context).clean();
+
+                InAppMessageStore store = InAppMessageStore.getInstance(context);
+                if (store != null) store.clean();
+
                 InAppManager.invokeTriggerWithinSdk();
             }
         } catch (Exception e) {
@@ -335,7 +338,8 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
                     BlueshiftExecutor.getInstance().runOnDiskIOThread(new Runnable() {
                         @Override
                         public void run() {
-                            InAppMessageStore.getInstance(context).markAsRead(messageUUIDs);
+                            InAppMessageStore store = InAppMessageStore.getInstance(context);
+                            if (store != null) store.markAsRead(messageUUIDs);
                         }
                     });
                 }

--- a/android-sdk/src/main/java/com/blueshift/framework/BaseSqliteTable.java
+++ b/android-sdk/src/main/java/com/blueshift/framework/BaseSqliteTable.java
@@ -204,14 +204,14 @@ public abstract class BaseSqliteTable<T> extends SQLiteOpenHelper {
                 new Runnable() {
                     @Override
                     public void run() {
-                        synchronized (lock) {
-                            try {
-                                BlueshiftLogger.i(LOG_TAG, "Deleting events from " + getTableName() + " started.");
+                        try {
+                            BlueshiftLogger.i(LOG_TAG, "Deleting events from " + getTableName() + " started.");
+                            synchronized (lock) {
                                 deleteAll();
-                            } catch (Exception e) {
-                                BlueshiftLogger.e(LOG_TAG, "Deleting events from " + getTableName() + " failed.");
-                                BlueshiftLogger.e(LOG_TAG, e);
                             }
+                        } catch (Exception e) {
+                            BlueshiftLogger.e(LOG_TAG, "Deleting events from " + getTableName() + " failed.");
+                            BlueshiftLogger.e(LOG_TAG, e);
                         }
                     }
                 }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -204,14 +204,7 @@ public class InAppManager {
                                 String responseBody = response.getBody();
 
                                 if (statusCode == 200) {
-                                    if (!TextUtils.isEmpty(responseBody)) {
-                                        try {
-                                            JSONArray inAppJsonArray = decodeResponse(responseBody);
-                                            InAppManager.onInAppMessageArrayReceived(context, inAppJsonArray);
-                                        } catch (Exception e) {
-                                            BlueshiftLogger.e(LOG_TAG, e);
-                                        }
-                                    }
+                                    handleInAppMessageApiResponse(context, responseBody);
 
                                     invokeApiSuccessCallback(callbackHandler, callback);
                                 } else {
@@ -248,6 +241,22 @@ public class InAppManager {
                     callback.onFailure(errorCode, errorMessage);
                 }
             });
+        }
+    }
+
+    /**
+     * This method can accept the in-app API response (JSON) and decode in-app messages from it.
+     * The decoded in-app messages will be inserted into the database and displayed to the user.
+     *
+     * @param context     valid context object
+     * @param apiResponse valid API response in JSON format
+     */
+    public static void handleInAppMessageApiResponse(Context context, String apiResponse) {
+        if (context != null && apiResponse != null && !apiResponse.isEmpty()) {
+            JSONArray messages = decodeResponse(apiResponse);
+            if (messages != null) onInAppMessageArrayReceived(context, messages);
+        } else {
+            BlueshiftLogger.d(LOG_TAG, "The context is null or the in-app API response is null or empty.");
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageStore.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageStore.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -53,8 +54,20 @@ public class InAppMessageStore extends BlueshiftBaseSQLiteOpenHelper<InAppMessag
         super(context, DB_NAME, null, DB_VERSION);
     }
 
-    public static InAppMessageStore getInstance(Context context) {
-        if (sInstance == null) sInstance = new InAppMessageStore(context);
+    /**
+     * This method maintains the singleton behavior of the class. At the same time, it prevents the
+     * possibility of passing null as context into the SQLiteOpenHelper instance. This is to avoid
+     * crashes while attempting to read the database path from null mContext variable.
+     *
+     * @param context valid {@link Context} variable
+     * @return {@link InAppMessageStore} object or null (if instance and context are both null)
+     */
+    @Nullable
+    public static InAppMessageStore getInstance(@NonNull Context context) {
+        if (sInstance == null && context != null) {
+            sInstance = new InAppMessageStore(context.getApplicationContext());
+        }
+
         return sInstance;
     }
 


### PR DESCRIPTION
- Ability to disable SDK's event tracking capability at runtime. Disabling this will stop sending custom events and metrics for push and in-app to Blueshift's servers. It will also remove any pending events (batched or real-time) that are yet to be sent.
- Added a public method to accept in-app API's response (as JSON) from the host app.
- Added a public method to generate the request body required for Blueshift's in-app API endpoint.
- Bug-fix: Added fix for a crash that occurs when the host app provides null Context to the SDK's SQLiteHelper implementation.