### PR TITLE
[MOBL-755] jCenter to MavenCentral migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.gpg
 *.iml
 .gradle
 /local.properties

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 ext {
     PUBLISH_GROUP_ID = 'com.blueshift'
     PUBLISH_ARTIFACT_ID = 'android-sdk'
-    PUBLISH_VERSION = '3.1.11'
+    PUBLISH_VERSION = '3.2.0'
 }
 
 android {

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -6,8 +6,6 @@ ext {
     PUBLISH_VERSION = '3.1.10'
 }
 
-apply from: "${rootProject.projectDir}/scripts/publish-mavencentral.gradle"
-
 android {
     compileSdkVersion 30
 
@@ -47,3 +45,5 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
 }
+
+apply from: "${rootProject.projectDir}/scripts/publish-mavencentral.gradle"

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -1,35 +1,23 @@
 apply plugin: 'com.android.library'
 
 ext {
-    // sdkOrg = 'blueshift-labs'
-    sdkOrg = 'nipun'
-    sdkGroup = 'com.blueshift'
-    sdkArtifactName = 'android-sdk'
-
-    sdkVersion = '3.1.10'
-    sdkVersionDesc = 'Blueshift Android SDK v' + sdkVersion
-    sdkVcsTag = sdkVersion
-
-    sdkName = 'Blueshift Android SDK'
-    sdkDesc = 'Blueshift Android SDK to make it easier for marketers to integrate their mobile app with Blueshift’s near real-time event processing platform and send personalized rich push notifications to their customers.'
-    sdkSite = 'https://github.com/blueshift-labs/Blueshift-Android-SDK'
-    sdkVcsUrl = 'https://github.com/blueshift-labs/Blueshift-Android-SDK.git'
-
-    sdkDevId = 'rahulrvp'
-    sdkDevName = 'Rahul Raveendran V P'
-    sdkDevEmail = 'rahul.raveendran@blueshift.com'
+    PUBLISH_GROUP_ID = 'com.blueshift'
+    PUBLISH_ARTIFACT_ID = 'android-sdk'
+    PUBLISH_VERSION = '3.1.10'
 }
 
+apply from: "${rootProject.projectDir}/scripts/publish-mavencentral.gradle"
+
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
-        buildConfigField 'String', 'SDK_VERSION', "\"$sdkVersion\""
+        buildConfigField 'String', 'SDK_VERSION', "\"$PUBLISH_VERSION\""
     }
     buildTypes {
         release {
@@ -57,89 +45,5 @@ dependencies {
     //noinspection GradleDependency
     implementation 'com.google.firebase:firebase-messaging:17.3.4'
 
-    testImplementation 'junit:junit:4.13'
-}
-
-// build a jar with source files
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    archiveClassifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    failOnError false
-    source = android.sourceSets.main.java.sourceFiles
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
-}
-// build a jar with javadoc
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-
-    publications = ['release']
-
-    pkg {
-        repo = 'maven'
-        name = sdkArtifactName
-        userOrg = sdkOrg
-        licenses = ['MIT']
-        vcsUrl = sdkVcsUrl
-        websiteUrl = sdkSite
-        desc = sdkDesc
-        publish = true
-        publicDownloadNumbers = true
-
-        version {
-            name = sdkVersion
-            desc = sdkVersionDesc
-            released = new Date()
-            vcsTag = sdkVcsTag
-
-            gpg {
-                sign = true
-                passphrase = System.getenv('BINTRAY_GPG')
-            }
-        }
-    }
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            // Creates a Maven publication called "release".
-            release(MavenPublication) {
-                // Applies the component for the release build variant.
-                from components.release
-
-                artifact sourcesJar
-                artifact javadocJar
-
-                // You can then customize attributes of the publication as shown below.
-                groupId = sdkGroup
-                artifactId = sdkArtifactName
-                version = sdkVersion
-
-                pom {
-                    developers {
-                        developer {
-                            id = sdkDevId
-                            name = sdkDevName
-                            email = sdkDevEmail
-                        }
-                    }
-                }
-            }
-        }
-    }
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 ext {
     PUBLISH_GROUP_ID = 'com.blueshift'
     PUBLISH_ARTIFACT_ID = 'android-sdk'
-    PUBLISH_VERSION = '3.1.10'
+    PUBLISH_VERSION = '3.1.11'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
     }
-}
-
-plugins {
-    id "com.jfrog.bintray" version "1.8.5"
-    id "maven-publish"
 }
 
 allprojects {

--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -1,0 +1,126 @@
+// credits for this code goes to this awesome blog's author
+// https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/
+
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        // For Android libraries
+        from android.sourceSets.main.java.srcDirs
+        // from android.sourceSets.main.kotlin.srcDirs
+    } else {
+        // For pure Kotlin libraries, in case you have them
+        from sourceSets.main.java.srcDirs
+        // from sourceSets.main.kotlin.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = PUBLISH_GROUP_ID
+version = PUBLISH_VERSION
+
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is ->
+        p.load(is)
+    }
+    p.each { name, value ->
+        ext[name] = value
+    }
+} else {
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+}
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            // The coordinates of the library, being set from variables that
+            // we'll set up later
+            groupId PUBLISH_GROUP_ID
+            artifactId PUBLISH_ARTIFACT_ID
+            version PUBLISH_VERSION
+
+            // Two artifacts, the `aar` (or `jar`) and the sources
+            if (project.plugins.findPlugin("com.android.library")) {
+                artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            } else {
+                artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+            }
+            artifact androidSourcesJar
+
+            // Mostly self-explanatory metadata
+            pom {
+                name = PUBLISH_ARTIFACT_ID
+                description = 'Blueshift Android SDK'
+                url = 'https://github.com/blueshift-labs/Blueshift-Android-SDK'
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://opensource.org/licenses/mit-license.php'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'rahulrvp'
+                        name = 'Rahul Raveendran V P'
+                        email = 'rahul.raveendran@getblueshift.com'
+                    }
+                    // Add all other devs here...
+                }
+                // Version control info - if you're using GitHub, follow the format as seen here
+                scm {
+                    connection = 'scm:git:github.com/blueshift-labs/Blueshift-Android-SDK.git'
+                    developerConnection = 'scm:git:ssh://github.com/blueshift-labs/Blueshift-Android-SDK.git'
+                    url = 'https://github.com/blueshift-labs/Blueshift-Android-SDK/tree/main'
+                }
+                // A slightly hacky fix so that your POM will include any transitive dependencies
+                // that your library builds upon
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+    // The repository to publish to, Sonatype/MavenCentral
+    repositories {
+        maven {
+            // This is an arbitrary name, you may also use "mavencentral" or
+            // any other name that's descriptive for you
+            name = "sonatype"
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username ossrhUsername
+                password ossrhPassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -112,10 +112,12 @@ publishing {
                     def dependenciesNode = asNode().appendNode('dependencies')
 
                     project.configurations.implementation.allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+                        if (!it.name.matches('unspecified')) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
                     }
                 }
             }

--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -17,8 +17,22 @@ task androidSourcesJar(type: Jar) {
     }
 }
 
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+    failOnError false
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 artifacts {
     archives androidSourcesJar
+    archives javadocJar
 }
 
 group = PUBLISH_GROUP_ID
@@ -65,6 +79,7 @@ publishing {
                 artifact("$buildDir/libs/${project.getName()}-${version}.jar")
             }
             artifact androidSourcesJar
+            artifact javadocJar
 
             // Mostly self-explanatory metadata
             pom {


### PR DESCRIPTION
This PR contains the code change required for publishing the library to MavenCentral via Sonatype.