### PR TITLE
[MOBL-828] Added enable_inapp flag that can be set during runtime

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAppPreferences.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAppPreferences.java
@@ -13,6 +13,7 @@ public class BlueshiftAppPreferences extends BlueshiftJSONObject {
     private static final String PREF_KEY = "bsft_app_preferences_json";
 
     private static final String KEY_ENABLE_PUSH = "bsft_enable_push";
+    private static final String KEY_ENABLE_IN_APP = "bsft_enable_in_app";
     private static final String KEY_ENABLE_TRACKING = "bsft_enable_tracking";
 
     private static final BlueshiftAppPreferences instance = new BlueshiftAppPreferences();
@@ -73,6 +74,31 @@ public class BlueshiftAppPreferences extends BlueshiftJSONObject {
             try {
                 if (instance.has(KEY_ENABLE_PUSH)) {
                     return instance.getBoolean(KEY_ENABLE_PUSH);
+                }
+            } catch (JSONException e) {
+                BlueshiftLogger.e(TAG, e);
+            }
+
+            // default true
+            return true;
+        }
+    }
+
+    public void setEnableInApp(boolean enableInApp) {
+        synchronized (instance) {
+            try {
+                instance.put(KEY_ENABLE_IN_APP, enableInApp);
+            } catch (JSONException e) {
+                BlueshiftLogger.e(TAG, e);
+            }
+        }
+    }
+
+    public boolean getEnableInApp() {
+        synchronized (instance) {
+            try {
+                if (instance.has(KEY_ENABLE_IN_APP)) {
+                    return instance.getBoolean(KEY_ENABLE_IN_APP);
                 }
             } catch (JSONException e) {
                 BlueshiftLogger.e(TAG, e);

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
@@ -280,21 +280,7 @@ public class BlueshiftAttributesApp extends JSONObject {
     }
 
     private void addPushEnabledStatus(Context context) {
-        boolean isEnabled = true;
-        try {
-            // read from system settings
-            NotificationManagerCompat notificationMgr = NotificationManagerCompat.from(context);
-            boolean systemPreferenceVal = notificationMgr.areNotificationsEnabled();
-
-            // read from app preferences
-            boolean appPreferenceVal = BlueshiftAppPreferences.getInstance(context).getEnablePush();
-
-            // push is enabled if it is enabled on both sides
-            isEnabled = systemPreferenceVal && appPreferenceVal;
-        } catch (Exception e) {
-            BlueshiftLogger.e(TAG, e);
-        }
-
+        boolean isEnabled = BlueshiftUtils.isOptedInForPushNotification(context);
         setPushEnabledStatus(isEnabled);
     }
 
@@ -309,20 +295,7 @@ public class BlueshiftAttributesApp extends JSONObject {
     }
 
     private void addInAppEnabledStatus(Context context) {
-        boolean isEnabled = true;
-        try {
-            // read from config
-            boolean configVal = BlueshiftUtils.isInAppEnabled(context);
-
-            // read from app preferences
-            boolean appPreferenceVal = BlueshiftAppPreferences.getInstance(context).getEnableInApp();
-
-            // push is enabled if it is enabled on both sides
-            isEnabled = configVal && appPreferenceVal;
-        } catch (Exception e) {
-            BlueshiftLogger.e(TAG, e);
-        }
-
+        boolean isEnabled = BlueshiftUtils.isOptedInForInAppMessages(context);
         setInAppEnabledStatus(isEnabled);
     }
 

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
@@ -309,8 +309,25 @@ public class BlueshiftAttributesApp extends JSONObject {
     }
 
     private void addInAppEnabledStatus(Context context) {
+        boolean isEnabled = true;
+        try {
+            // read from config
+            boolean configVal = BlueshiftUtils.isInAppEnabled(context);
+
+            // read from app preferences
+            boolean appPreferenceVal = BlueshiftAppPreferences.getInstance(context).getEnableInApp();
+
+            // push is enabled if it is enabled on both sides
+            isEnabled = configVal && appPreferenceVal;
+        } catch (Exception e) {
+            BlueshiftLogger.e(TAG, e);
+        }
+
+        setInAppEnabledStatus(isEnabled);
+    }
+
+    private void setInAppEnabledStatus(boolean isEnabled) {
         synchronized (instance) {
-            boolean isEnabled = BlueshiftUtils.isInAppEnabled(context);
             try {
                 instance.put(BlueshiftConstants.KEY_ENABLE_INAPP, isEnabled);
             } catch (JSONException e) {
@@ -387,6 +404,12 @@ public class BlueshiftAttributesApp extends JSONObject {
 
         try {
             addPushEnabledStatus(context);
+        } catch (Exception e) {
+            BlueshiftLogger.e(TAG, e);
+        }
+
+        try {
+            addInAppEnabledStatus(context);
         } catch (Exception e) {
             BlueshiftLogger.e(TAG, e);
         }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -170,7 +170,7 @@ public class InAppManager {
     }
 
     public static void fetchInAppFromServer(final Context context, final InAppApiCallback callback) {
-        boolean isEnabled = BlueshiftUtils.isInAppEnabled(context);
+        boolean isEnabled = BlueshiftUtils.isOptedInForInAppMessages(context);
         if (isEnabled) {
             final Handler callbackHandler = getCallbackHandler(callback);
             BlueshiftExecutor.getInstance().runOnNetworkThread(
@@ -351,7 +351,7 @@ public class InAppManager {
      * @param inAppMessage valid inAppMessage object
      */
     public static void onInAppMessageReceived(Context context, InAppMessage inAppMessage) {
-        boolean isEnabled = BlueshiftUtils.isInAppEnabled(context);
+        boolean isEnabled = BlueshiftUtils.isOptedInForInAppMessages(context);
         if (isEnabled) {
             BlueshiftLogger.d(LOG_TAG, "In-app message received. Message UUID: " + (inAppMessage != null ? inAppMessage.getMessageUuid() : null));
 
@@ -396,7 +396,7 @@ public class InAppManager {
             return;
         }
 
-        boolean isEnabled = BlueshiftUtils.isInAppEnabled(mActivity);
+        boolean isEnabled = BlueshiftUtils.isOptedInForInAppMessages(mActivity);
         if (isEnabled) {
             try {
                 BlueshiftExecutor.getInstance().runOnDiskIOThread(new Runnable() {

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -210,6 +210,8 @@ public class InAppManager {
                         }
                     }
             );
+        } else {
+            BlueshiftLogger.w(LOG_TAG, "In-app is opted-out. Can not fetch in-app messages from API.");
         }
     }
 
@@ -374,6 +376,8 @@ public class InAppManager {
                     BlueshiftLogger.d(LOG_TAG, "Expired in-app received. Message UUID: " + inAppMessage.getMessageUuid());
                 }
             }
+        } else {
+            BlueshiftLogger.w(LOG_TAG, "In-app is opted-out. Can not accept in-app messages.");
         }
     }
 
@@ -423,6 +427,8 @@ public class InAppManager {
             } catch (Exception e) {
                 BlueshiftLogger.e(LOG_TAG, e);
             }
+        } else {
+            BlueshiftLogger.w(LOG_TAG, "In-app opted-out. Can not display in-app messages.");
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/BlueshiftUtils.java
@@ -3,20 +3,19 @@ package com.blueshift.util;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.WorkerThread;
+import android.support.v4.app.NotificationManagerCompat;
 import android.text.TextUtils;
 
 import com.blueshift.BlueShiftPreference;
 import com.blueshift.Blueshift;
+import com.blueshift.BlueshiftAppPreferences;
 import com.blueshift.BlueshiftConstants;
 import com.blueshift.BlueshiftLogger;
 import com.blueshift.BuildConfig;
 import com.blueshift.model.Configuration;
 import com.blueshift.rich_push.Message;
 import com.google.firebase.messaging.RemoteMessage;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -123,6 +122,51 @@ public class BlueshiftUtils {
         }
 
         return isEnabled;
+    }
+
+    /**
+     * Checks both config and app preferences to see if the user has opted in for in-app messages.
+     * Both the flags should be enabled to opt in for in-app messages.
+     *
+     * @param context valid context object
+     * @return true if in-app is ON in both app preferences and config object
+     */
+    public static boolean isOptedInForInAppMessages(Context context) {
+        try {
+            // read from config
+            boolean configVal = BlueshiftUtils.isInAppEnabled(context);
+
+            // read from app preferences
+            boolean appPreferenceVal = BlueshiftAppPreferences.getInstance(context).getEnableInApp();
+
+            // push is enabled if it is enabled on both sides
+            return configVal && appPreferenceVal;
+        } catch (Exception e) {
+            return true; // enabled by default
+        }
+    }
+
+    /**
+     * Checks both system settings and app preferences to see if the user has opted in for push
+     * notifications. Both the flags should be enabled to opt in for push notification.
+     *
+     * @param context valid context object
+     * @return true if push is ON in both app preferences and system settings, else false
+     */
+    public static boolean isOptedInForPushNotification(Context context) {
+        try {
+            // read from system settings
+            NotificationManagerCompat notificationMgr = NotificationManagerCompat.from(context);
+            boolean systemPreferenceVal = notificationMgr.areNotificationsEnabled();
+
+            // read from app preferences
+            boolean appPreferenceVal = BlueshiftAppPreferences.getInstance(context).getEnablePush();
+
+            // push is enabled if it is enabled on both sides
+            return systemPreferenceVal && appPreferenceVal;
+        } catch (Exception e) {
+            return true; // enabled by default
+        }
     }
 
     /**


### PR DESCRIPTION
The default value is `true` if no value found in preference (older sdk users)

The value sent in event request params is calculated as follows.
```
isEnabled = "The value from config" AND "The value from the app preference"
```