### PR TITLE
[MOBL-820] Fixed time format string to accept 24h

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/CommonUtils.java
@@ -95,10 +95,9 @@ public class CommonUtils {
     }
 
     public static String getCurrentUtcTimestamp() {
-        Date now = new Date(System.currentTimeMillis());
-        SimpleDateFormat sdf = new SimpleDateFormat(
-                "yyyy-MM-dd'T'hh:mm:ss.SSSSSS'Z'", Locale.getDefault());
+        String formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
+        SimpleDateFormat sdf = new SimpleDateFormat(formatString, Locale.getDefault());
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return sdf.format(now);
+        return sdf.format(new Date());
     }
 }


### PR DESCRIPTION
The initial format string was taking the hours in 12h format where our API is expecting it in 24h format. This is a fix to correct that bug.