### PR TITLE
[MOBL-836] Added the deep link URL as data Uri to the Intent

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -11,6 +11,7 @@ import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -581,6 +582,13 @@ public class NotificationUtils {
 
                     // add complete bundle to the intent.
                     intent.putExtras(bundle);
+
+                    try {
+                        // add deep link URL to the intent's data as well.
+                        if (deepLink != null) intent.setData(Uri.parse(deepLink));
+                    } catch (Exception e) {
+                        BlueshiftLogger.e(LOG_TAG, e);
+                    }
 
                     // Note: This will create a new task and launch the app with the corresponding
                     // activity. As per the docs, the dev should add parent activity to all the


### PR DESCRIPTION
The deep link URL usually comes inside Intent as Uri. The host app calls the getData method to get it. But in our case, we send it as an extra attribute to the activity called `deep_link_url`. This change makes the deep link URL available as data Uri as well.