### PR TITLE
added helper method to parse message from extras and avoid crashes

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsService.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsService.java
@@ -61,7 +61,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
                     BlueshiftLogger.d(LOG_TAG, "No bundle data available with the broadcast.");
                 }
 
-                Message message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
+                Message message = Message.fromIntent(intent);
 
                 // remove cached images(if any) for this notification
                 NotificationUtils.removeCachedCarouselImages(this, message);
@@ -83,7 +83,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayProductPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getProductPage() != null) {
@@ -110,7 +110,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void addToCart(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getCartPage() != null) {
@@ -137,7 +137,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayCartPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getCartPage() != null) {
@@ -159,7 +159,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void displayOfferDisplayPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = BlueshiftUtils.getConfiguration(context);
             if (configuration != null && configuration.getOfferDisplayPage() != null) {
@@ -181,7 +181,7 @@ public class BlueshiftNotificationEventsService extends IntentService {
     }
 
     public void openApp(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             PackageManager packageManager = context.getPackageManager();
             Intent launcherIntent = packageManager.getLaunchIntentForPackage(context.getPackageName());

--- a/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/Message.java
@@ -1,6 +1,11 @@
 package com.blueshift.rich_push;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.text.TextUtils;
+
+import com.blueshift.BlueshiftConstants;
+import com.blueshift.BlueshiftLogger;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -13,6 +18,7 @@ import java.util.Map;
  * https://github.com/rahulrvp
  */
 public class Message implements Serializable {
+    private static final String TAG = "Message";
     public static final String EXTRA_MESSAGE = "message";
     public static final String EXTRA_BSFT_EXPERIMENT_UUID = "bsft_experiment_uuid";
     public static final String EXTRA_BSFT_USER_UUID = "bsft_user_uuid";
@@ -199,6 +205,24 @@ public class Message implements Serializable {
         map.put("notification_channel_description", notification_channel_description);
 
         return map;
+    }
+
+    public static Message fromIntent(Intent intent) {
+        return intent != null ? fromBundle(intent.getExtras()) : null;
+    }
+
+    public static Message fromBundle(Bundle bundle) {
+        Message message = null;
+
+        if (bundle != null && bundle.containsKey(RichPushConstants.EXTRA_MESSAGE)) {
+            try {
+                message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+            } catch (Exception e) {
+                BlueshiftLogger.e(TAG, e);
+            }
+        }
+
+        return message;
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationActivity.java
@@ -36,11 +36,7 @@ public class NotificationActivity extends AppCompatActivity {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
         mContext = this;
-
-        try {
-            mMessage = (Message) getIntent().getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
-        } catch (Exception ignore) {
-        }
+        mMessage = Message.fromIntent(getIntent());
 
         if (mMessage != null) {
             int theme = 0;

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationWorker.java
@@ -35,11 +35,7 @@ public class NotificationWorker extends IntentService {
 
         if (action == null) return;
 
-        Message message = null;
-        try {
-            message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
-        } catch (Exception ignore) {
-        }
+        Message message = Message.fromIntent(intent);
 
         if (message == null) return;
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushActionReceiver.java
@@ -48,11 +48,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
                 BlueshiftLogger.d(LOG_TAG, "No bundle data available with the broadcast.");
             }
 
-            Message message = null;
-            try {
-                message = (Message) intent.getSerializableExtra(RichPushConstants.EXTRA_MESSAGE);
-            } catch (Exception ignore) {
-            }
+            Message message = Message.fromIntent(intent);
 
             if (message == null) return;
 
@@ -75,7 +71,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayProductPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getProductPage() != null) {
@@ -102,7 +98,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void addToCart(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getCartPage() != null) {
@@ -129,7 +125,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayCartPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getCartPage() != null) {
@@ -151,7 +147,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void displayOfferDisplayPage(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             Configuration configuration = Blueshift.getInstance(context).getConfiguration();
             if (configuration != null && configuration.getOfferDisplayPage() != null) {
@@ -173,7 +169,7 @@ public class RichPushActionReceiver extends BroadcastReceiver {
     }
 
     public void openApp(Context context, Bundle bundle) {
-        Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+        Message message = Message.fromBundle(bundle);
         if (message != null) {
             PackageManager packageManager = context.getPackageManager();
             Intent launcherIntent = packageManager.getLaunchIntentForPackage(context.getPackageName());

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -551,7 +551,7 @@ public class NotificationUtils {
      */
     public static boolean processNotificationClick(Context context, String action, Bundle bundle) {
         if (context != null && action != null && bundle != null) {
-            Message message = (Message) bundle.getSerializable(RichPushConstants.EXTRA_MESSAGE);
+            Message message = Message.fromBundle(bundle);
             if (message != null) {
                 try {
                     String deepLink = bundle.getString(RichPushConstants.EXTRA_DEEP_LINK_URL);


### PR DESCRIPTION
This fix avoids app crashes on some Samsung devices on some of their os versions.
The issue identified is with the native method `getSerializableExtra` that fails to provide the result.