### PR TITLE
add check before passing saved instance to super.onCreate

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
@@ -6,7 +6,11 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 import com.blueshift.BlueshiftLogger;
+import com.blueshift.rich_push.Message;
+import com.blueshift.rich_push.RichPushConstants;
 import com.blueshift.util.NotificationUtils;
+
+import java.io.Serializable;
 
 
 /**
@@ -16,9 +20,19 @@ import com.blueshift.util.NotificationUtils;
  */
 
 public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
+    private static final String TAG = "PNEventsActivity";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        Message message = Message.fromBundle(savedInstanceState);
+        if (message == null) {
+            // The message is null if one of the following cases is true
+            // 1. The parcelable failed to extract the message object
+            // 2. The bundle does not have the message object
+            // in case of (1), remove the message object to avoid any possible crashes.
+            removeMessage(savedInstanceState);
+        }
+
         super.onCreate(savedInstanceState);
 
         Intent intent = getIntent();
@@ -28,7 +42,14 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
         if (!isFinishing()) {
             finish();
         } else {
-            BlueshiftLogger.d("NotificationEventsActivity", "finish() called externally.");
+            BlueshiftLogger.d(TAG, "finish() called externally.");
+        }
+    }
+
+    private void removeMessage(Bundle bundle) {
+        if (bundle != null && bundle.containsKey(RichPushConstants.EXTRA_MESSAGE)) {
+            BlueshiftLogger.d(TAG, "Removing the message object to avoid crashes.");
+            bundle.remove(RichPushConstants.EXTRA_MESSAGE);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
+++ b/android-sdk/src/main/java/com/blueshift/pn/BlueshiftNotificationEventsActivity.java
@@ -29,8 +29,10 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
             // The message is null if one of the following cases is true
             // 1. The parcelable failed to extract the message object
             // 2. The bundle does not have the message object
-            // in case of (1), remove the message object to avoid any possible crashes.
+            // in case of (1), remove the message object and carousel element object (if any)
+            // to avoid any possible crashes.
             removeMessage(savedInstanceState);
+            removeCarouselElement(savedInstanceState);
         }
 
         super.onCreate(savedInstanceState);
@@ -50,6 +52,13 @@ public class BlueshiftNotificationEventsActivity extends AppCompatActivity {
         if (bundle != null && bundle.containsKey(RichPushConstants.EXTRA_MESSAGE)) {
             BlueshiftLogger.d(TAG, "Removing the message object to avoid crashes.");
             bundle.remove(RichPushConstants.EXTRA_MESSAGE);
+        }
+    }
+
+    private void removeCarouselElement(Bundle bundle) {
+        if (bundle != null && bundle.containsKey(RichPushConstants.EXTRA_CAROUSEL_ELEMENT)) {
+            BlueshiftLogger.d(TAG, "Removing the carousel element object to avoid crashes.");
+            bundle.remove(RichPushConstants.EXTRA_CAROUSEL_ELEMENT);
         }
     }
 


### PR DESCRIPTION
This check prevents crashes inside the super.onCreate by removing the message object from the savedinstance object