### PR TITLE
[MOBL-873] improve background processing

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueshiftExecutor.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftExecutor.java
@@ -66,15 +66,4 @@ public class BlueshiftExecutor {
             uiHandler.post(runnable);
         }
     }
-
-    public Handler getMyHandler() {
-        Handler handler = null;
-        Looper looper = Looper.myLooper();
-
-        if (looper != null) {
-            handler = new Handler(looper);
-        }
-
-        return handler;
-    }
 }

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppManager.java
@@ -198,32 +198,44 @@ public class InAppManager {
 
                                     if (statusCode == 200) {
                                         handleInAppMessageAPIResponse(context, responseBody);
-
-                                        if (callback != null) {
-                                            callback.onSuccess();
-                                        }
+                                        invokeApiSuccessCallback(callback);
                                     } else {
-                                        if (callback != null) {
-                                            callback.onFailure(statusCode, responseBody);
-                                        }
+                                        invokeApiFailureCallback(callback, statusCode, responseBody);
                                     }
                                 } else {
-                                    if (callback != null) {
-                                        callback.onFailure(0, "Could not make the API call.");
-                                    }
+                                    invokeApiFailureCallback(callback, 0, "Could not make the API call.");
                                 }
                             } catch (Exception e) {
                                 BlueshiftLogger.e(LOG_TAG, e);
-
-                                if (callback != null) {
-                                    callback.onFailure(0, e.getMessage());
-                                }
+                                invokeApiFailureCallback(callback, 0, e.getMessage());
                             }
                         }
                     }
             );
         } else {
             BlueshiftLogger.w(LOG_TAG, "In-app is opted-out. Can not fetch in-app messages from API.");
+        }
+    }
+
+    private static void invokeApiSuccessCallback(final InAppApiCallback callback) {
+        if (callback != null) {
+            BlueshiftExecutor.getInstance().runOnMainThread(new Runnable() {
+                @Override
+                public void run() {
+                    callback.onSuccess();
+                }
+            });
+        }
+    }
+
+    private static void invokeApiFailureCallback(final InAppApiCallback callback, final int code, final String message) {
+        if (callback != null) {
+            BlueshiftExecutor.getInstance().runOnMainThread(new Runnable() {
+                @Override
+                public void run() {
+                    callback.onFailure(code, message);
+                }
+            });
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -408,27 +408,16 @@ class RequestDispatcher {
     }
 
     private void dispatchWithToken(final String deviceToken) {
-        final Handler handler = BlueshiftExecutor.getInstance().getMyHandler();
         invokeDispatchBegin();
-        if (handler != null) {
-            BlueshiftExecutor.getInstance().runOnNetworkThread(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            processRequest(deviceToken);
-                            handler.post(new Runnable() {
-                                @Override
-                                public void run() {
-                                    invokeDispatchComplete();
-                                }
-                            });
-                        }
+        BlueshiftExecutor.getInstance().runOnNetworkThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        processRequest(deviceToken);
+                        invokeDispatchComplete();
                     }
-            );
-        } else {
-            BlueshiftLogger.e(LOG_TAG, "Could not create Handler to process request.");
-            invokeDispatchComplete();
-        }
+                }
+        );
     }
 
     public interface Callback {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -86,25 +86,15 @@ public class NotificationFactory {
     @Deprecated
     private static void buildAndShowAlertDialog(final Context context, final Message message) {
         if (context != null && message != null) {
-            final Handler handler = BlueshiftExecutor.getInstance().getMyHandler();
-            if (handler != null) {
-                BlueshiftExecutor.getInstance().runOnWorkerThread(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                final boolean appInForeground = isAppInForeground(context);
-                                handler.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        launchNotificationActivity(context, message, appInForeground);
-                                    }
-                                });
-                            }
+            BlueshiftExecutor.getInstance().runOnWorkerThread(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            final boolean appInForeground = isAppInForeground(context);
+                            launchNotificationActivity(context, message, appInForeground);
                         }
-                );
-            } else {
-                BlueshiftLogger.e(LOG_TAG, "No handler found.");
-            }
+                    }
+            );
         }
     }
 


### PR DESCRIPTION
Context: The threads in the thread pool do not have a Looper. This blocks us from creating a handler for these threads.

Q. What are we doing with this change?
A. Avoiding creating handlers based on the current thread's looper.

How?
- The API callbacks are now posted back to the UI thread so that the caller can update the UI.
- The request dispatcher does the dispatching from a network thread depending on the caller's handler. The callback for this can be invoked from the network thread as the caller itself is invoked from the worker thread.
