### PR TITLE
[MOBL-1015] Set exported flags explicitly for targeting Android S

### DIFF
--- a/android-sdk/src/main/AndroidManifest.xml
+++ b/android-sdk/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         <activity
             android:name=".pn.BlueshiftNotificationEventsActivity"
             android:configChanges="orientation|screenSize"
+            android:exported="false"
             android:theme="@style/TransparentActivity" />
 
         <!--Events batching-->
@@ -40,14 +41,18 @@
             android:name=".rich_push.NotificationWorker"
             android:exported="false" />
 
-        <receiver android:name=".rich_push.ScheduledPushReceiver">
+        <receiver
+            android:name=".rich_push.ScheduledPushReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="${applicationId}.ACTION_SCHEDULED_PUSH" />
             </intent-filter>
         </receiver>
 
         <!-- NW Change: This broadcast receiver is added for Android API version 23 and below.-->
-        <receiver android:name=".receiver.NetworkChangeListener">
+        <receiver
+            android:name=".receiver.NetworkChangeListener"
+            android:exported="false">
             <intent-filter>
                 <action
                     android:name="android.net.conn.CONNECTIVITY_CHANGE"


### PR DESCRIPTION
This change adds support to [this](https://developer.android.com/about/versions/12/behavior-changes-12#exported) behavioral change in Android S.