### PR TITLE
[MOBL-1054] Android 12: Removed the broadcast with action ACTION_CLOSE_SYSTEM_DIALOGS

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -518,8 +518,6 @@ public class NotificationUtils {
                         notificationManager.cancel(notificationID);
                     }
 
-                    context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
-
                     // click was handled by Blueshift SDK
                     return true;
                 } catch (Exception e) {


### PR DESCRIPTION
[MOBL-1054] Android 12: Removed the broadcast with action ACTION_CLOSE_SYSTEM_DIALOGS

[MOBL-1054]: https://blueshift.atlassian.net/browse/MOBL-1054

This broadcast was fired by the sdk to close the notification drawer or recent apps window when we used to display the dialog type notification. This is no longer needed in the SDK. Also, Android 12 has a [behavioral change](https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs) related to this.