### PR TITLE
[MOBL-1067] Stopped sending delivered events for push notifications

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1141,7 +1141,8 @@ public class Blueshift {
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.
+     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
     public void trackNotificationView(Message message) {
@@ -1149,6 +1150,7 @@ public class Blueshift {
             if (message.getBsftSeedListSend()) {
                 BlueshiftLogger.d(LOG_TAG, "Seed List Send. Event skipped: " + BlueshiftConstants.EVENT_PUSH_DELIVERED);
             } else {
+                //noinspection deprecation
                 trackNotificationView(message.getId(), message.getCampaignAttr());
             }
         } else {
@@ -1158,16 +1160,19 @@ public class Blueshift {
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.
+     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
     public void trackNotificationView(String notificationId) {
+        //noinspection deprecation
         trackNotificationView(notificationId, null);
     }
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.
+     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
     @SuppressWarnings("WeakerAccess")

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1139,6 +1139,11 @@ public class Blueshift {
         }
     }
 
+    /**
+     * @since 3.2.5
+     * @deprecated The delivered event sent by the SDK is deprecated.
+     */
+    @Deprecated
     public void trackNotificationView(Message message) {
         if (message != null) {
             if (message.getBsftSeedListSend()) {
@@ -1151,20 +1156,25 @@ public class Blueshift {
         }
     }
 
+    /**
+     * @since 3.2.5
+     * @deprecated The delivered event sent by the SDK is deprecated.
+     */
+    @Deprecated
     public void trackNotificationView(String notificationId) {
         trackNotificationView(notificationId, null);
     }
 
+    /**
+     * @since 3.2.5
+     * @deprecated The delivered event sent by the SDK is deprecated.
+     */
+    @Deprecated
     @SuppressWarnings("WeakerAccess")
     public void trackNotificationView(String notificationId, HashMap<String, Object> params) {
-        HashMap<String, Object> eventParams = new HashMap<>();
-        eventParams.put(Message.EXTRA_BSFT_MESSAGE_UUID, notificationId);
-
-        if (params != null) {
-            eventParams.putAll(params);
-        }
-
-        trackCampaignEventAsync(BlueshiftConstants.EVENT_PUSH_DELIVERED, eventParams, null);
+        // The delivered event sent by the SDK was a read-receipt/acknowledgement.
+        // Blueshift will now provide the actual delivery stats based on the FCM's response.
+        BlueshiftLogger.w(LOG_TAG, "delivered event is deprecated. Skipping the event.");
     }
 
     public void trackNotificationClick(Message message, HashMap<String, Object> extras) {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1141,7 +1141,7 @@ public class Blueshift {
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
      * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
@@ -1160,7 +1160,7 @@ public class Blueshift {
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
      * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
@@ -1171,14 +1171,14 @@ public class Blueshift {
 
     /**
      * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated.The SDK will no longer send the
+     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
      * delivered event for push notifications, and this method will be removed in a future release.
      */
     @Deprecated
     @SuppressWarnings("WeakerAccess")
     public void trackNotificationView(String notificationId, HashMap<String, Object> params) {
         // The delivered event sent by the SDK was a read-receipt/acknowledgement.
-        // Blueshift will now provide the actual delivery stats based on the FCM's response.
+        // Blueshift will now provide the push delivery stats based on the FCM's response.
         BlueshiftLogger.w(LOG_TAG, "delivered event is deprecated. Skipping the event.");
     }
 

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -1140,9 +1140,11 @@ public class Blueshift {
     }
 
     /**
-     * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
-     * delivered event for push notifications, and this method will be removed in a future release.
+     * @since 3.2.8
+     * @deprecated The delivered event sent by the SDK is deprecated. Blueshift now computes the
+     * push delivery stats based on the response received from FCM. <a href="https://blueshift.com/library/product-update/release-21-11-1/#definition">Know more</a>
+     * <p>
+     * This method will be removed from the SDK in a future release.
      */
     @Deprecated
     public void trackNotificationView(Message message) {
@@ -1159,9 +1161,11 @@ public class Blueshift {
     }
 
     /**
-     * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
-     * delivered event for push notifications, and this method will be removed in a future release.
+     * @since 3.2.8
+     * @deprecated The delivered event sent by the SDK is deprecated. Blueshift now computes the
+     * push delivery stats based on the response received from FCM. <a href="https://blueshift.com/library/product-update/release-21-11-1/#definition">Know more</a>
+     * <p>
+     * This method will be removed from the SDK in a future release.
      */
     @Deprecated
     public void trackNotificationView(String notificationId) {
@@ -1170,9 +1174,11 @@ public class Blueshift {
     }
 
     /**
-     * @since 3.2.5
-     * @deprecated The delivered event sent by the SDK is deprecated. The SDK will no longer send the
-     * delivered event for push notifications, and this method will be removed in a future release.
+     * @since 3.2.8
+     * @deprecated The delivered event sent by the SDK is deprecated. Blueshift now computes the
+     * push delivery stats based on the response received from FCM. <a href="https://blueshift.com/library/product-update/release-21-11-1/#definition">Know more</a>
+     * <p>
+     * This method will be removed from the SDK in a future release.
      */
     @Deprecated
     @SuppressWarnings("WeakerAccess")

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -595,8 +595,6 @@ public class NotificationUtils {
                 Blueshift.getBlueshiftPushListener().onPushDelivered(attr);
             }
         }
-
-        Blueshift.getInstance(context).trackNotificationView(message);
     }
 
     /**


### PR DESCRIPTION
The push delivered sent by the SDK was a read receipt (acknowledgment). This was often getting confused with the delivered metric we show on the dashboard. This change will help in showing correct stats for delivered based on the response we get from the service provider (FCM/APNS).