### PR TITLE
[MOBL-1280] Deprecated AAID as device-id-source and new default is FID:package_name

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -68,7 +68,34 @@ public class Blueshift {
     private static BlueshiftInAppListener blueshiftInAppListener;
 
     public enum DeviceIdSource {
-        ADVERTISING_ID, INSTANCE_ID, GUID, ADVERTISING_ID_PKG_NAME, INSTANCE_ID_PKG_NAME, CUSTOM
+        /**
+         * @deprecated According to <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">this documentation</a>,
+         * starting April 1st, 2022, Android Advertising ID may become a string of 0s if the user
+         * opts out of Ad personalisation. Blueshift SDK is changing its default device_id source
+         * from ADVERTISING_ID to INSTANCE_ID_PKG_NAME. So, even if you are explicitly setting the
+         * device_id source as ADVERTISING_ID or ADVERTISING_ID_PKG_NAME, the SDK will start using
+         * the INSTANCE_ID_PKG_NAME option as its device_id source when you upgrade to v3.2.6 or above.
+         * <p>
+         * For assistance, reach out to your CSM or send us an email to support@blueshift.com.
+         */
+        @Deprecated
+        ADVERTISING_ID,
+        INSTANCE_ID,
+        GUID,
+        /**
+         * @deprecated According to <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">this documentation</a>,
+         * starting April 1st, 2022, Android Advertising ID may become a string of 0s if the user
+         * opts out of Ad personalisation. Blueshift SDK is changing its default device_id source
+         * from ADVERTISING_ID to INSTANCE_ID_PKG_NAME. So, even if you are explicitly setting the
+         * device_id source as ADVERTISING_ID or ADVERTISING_ID_PKG_NAME, the SDK will start using
+         * the INSTANCE_ID_PKG_NAME option as its device_id source when you upgrade to v3.2.6 or above.
+         * <p>
+         * For assistance, reach out to your CSM or send us an email to support@blueshift.com.
+         */
+        @Deprecated
+        ADVERTISING_ID_PKG_NAME,
+        INSTANCE_ID_PKG_NAME,
+        CUSTOM
     }
 
     private Blueshift(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -9,9 +9,10 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
-import android.text.TextUtils;
 
 import com.blueshift.batch.BulkEventManager;
 import com.blueshift.batch.Event;
@@ -38,9 +39,6 @@ import com.blueshift.util.BlueshiftUtils;
 import com.blueshift.util.CommonUtils;
 import com.blueshift.util.DeviceUtils;
 import com.blueshift.util.NetworkUtils;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.FirebaseApp;
 import com.google.gson.Gson;
 
 import org.json.JSONException;
@@ -69,12 +67,15 @@ public class Blueshift {
 
     public enum DeviceIdSource {
         /**
-         * @deprecated According to <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">this documentation</a>,
-         * starting April 1st, 2022, Android Advertising ID may become a string of 0s if the user
-         * opts out of Ad personalisation. Blueshift SDK is changing its default device_id source
-         * from ADVERTISING_ID to INSTANCE_ID_PKG_NAME. So, even if you are explicitly setting the
-         * device_id source as ADVERTISING_ID or ADVERTISING_ID_PKG_NAME, the SDK will start using
-         * the INSTANCE_ID_PKG_NAME option as its device_id source when you upgrade to v3.2.6 or above.
+         * @since 3.2.6
+         * @deprecated Starting SDK version 3.2.6, we are deprecating the device id sources
+         * “Android Advertising ID” and “Android Advertising ID:Package Name” owing to the changes
+         * Google introduced to the <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">Advertising ID</a>
+         * collection starting April 1st, 2022.
+         * <p>
+         * “Firebase Instance ID:Package Name” would be the new default device id source for the SDK,
+         * even if the app has explicitly specified the device id source as “Android Advertising ID”
+         * or “Android Advertising ID:Package Name”.
          * <p>
          * For assistance, reach out to your CSM or send us an email to support@blueshift.com.
          */
@@ -83,12 +84,15 @@ public class Blueshift {
         INSTANCE_ID,
         GUID,
         /**
-         * @deprecated According to <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">this documentation</a>,
-         * starting April 1st, 2022, Android Advertising ID may become a string of 0s if the user
-         * opts out of Ad personalisation. Blueshift SDK is changing its default device_id source
-         * from ADVERTISING_ID to INSTANCE_ID_PKG_NAME. So, even if you are explicitly setting the
-         * device_id source as ADVERTISING_ID or ADVERTISING_ID_PKG_NAME, the SDK will start using
-         * the INSTANCE_ID_PKG_NAME option as its device_id source when you upgrade to v3.2.6 or above.
+         * @since 3.2.6
+         * @deprecated Starting SDK version 3.2.6, we are deprecating the device id sources
+         * “Android Advertising ID” and “Android Advertising ID:Package Name” owing to the changes
+         * Google introduced to the <a href="https://support.google.com/googleplay/android-developer/answer/6048248?hl=en">Advertising ID</a>
+         * collection starting April 1st, 2022.
+         * <p>
+         * “Firebase Instance ID:Package Name” would be the new default device id source for the SDK,
+         * even if the app has explicitly specified the device id source as “Android Advertising ID”
+         * or “Android Advertising ID:Package Name”.
          * <p>
          * For assistance, reach out to your CSM or send us an email to support@blueshift.com.
          */

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
@@ -162,14 +162,6 @@ public class BlueshiftAttributesApp extends JSONObject {
                     setFirebaseInstanceIdAsDeviceId();
                     break;
 
-                case INSTANCE_ID_PKG_NAME:
-                    setFirebaseInstanceIdPackageNameAsDeviceId(context);
-                    break;
-
-                case ADVERTISING_ID_PKG_NAME:
-                    setAdvertisingIdPackageNameAsDeviceId(context);
-                    break;
-
                 case GUID:
                     setGUIDAsDeviceId(context);
                     break;
@@ -179,12 +171,12 @@ public class BlueshiftAttributesApp extends JSONObject {
                     break;
 
                 default:
-                    // DEFAULT value is Android Ad ID
-                    setAdvertisingIdAsDeviceId(context);
+                    // DEFAULT value is FID:package_name
+                    setFirebaseInstanceIdPackageNameAsDeviceId(context);
             }
         } else {
-            // DEFAULT value is Android Ad ID
-            setAdvertisingIdAsDeviceId(context);
+            // DEFAULT value is FID:package_name
+            setFirebaseInstanceIdPackageNameAsDeviceId(context);
         }
     }
 

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -76,8 +76,8 @@ public class Configuration {
         // Push Messaging
         pushEnabled = true;
 
-        // Default device_id: Android Ad Id
-        deviceIdSource = Blueshift.DeviceIdSource.ADVERTISING_ID;
+        // Default device_id: FID:package_name
+        deviceIdSource = Blueshift.DeviceIdSource.INSTANCE_ID_PKG_NAME;
 
         // Default bulk event interval: 30min
         batchInterval = AlarmManager.INTERVAL_HALF_HOUR;


### PR DESCRIPTION
AndroidX version of #296 