### PR TITLE
[MOBL-1254] Avoid ANR caused by various reasons

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -432,8 +432,14 @@ public class Blueshift {
     }
 
     private void updateFirebaseInstanceId() {
-        String instanceId = FirebaseInstanceId.getInstance().getId();
-        setFirebaseInstanceId(instanceId);
+        Task<InstanceIdResult> resultTask = FirebaseInstanceId.getInstance().getInstanceId();
+        resultTask.addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+            @Override
+            public void onSuccess(InstanceIdResult instanceIdResult) {
+                String instanceId = instanceIdResult.getId();
+                setFirebaseInstanceId(instanceId);
+            }
+        });
     }
 
     private void setFirebaseInstanceId(String instanceId) {

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftAttributesApp.java
@@ -259,8 +259,14 @@ public class BlueshiftAttributesApp extends JSONObject {
     }
 
     private void addFirebaseInstanceId() {
-        String instanceId = FirebaseInstanceId.getInstance().getId();
-        setFirebaseInstanceId(instanceId);
+        Task<InstanceIdResult> resultTask = FirebaseInstanceId.getInstance().getInstanceId();
+        resultTask.addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+            @Override
+            public void onSuccess(InstanceIdResult instanceIdResult) {
+                String instanceId = instanceIdResult.getId();
+                setFirebaseInstanceId(instanceId);
+            }
+        });
     }
 
     private void setFirebaseInstanceId(String instanceId) {

--- a/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
+++ b/android-sdk/src/main/java/com/blueshift/fcm/BlueshiftMessagingService.java
@@ -395,18 +395,7 @@ public class BlueshiftMessagingService extends FirebaseMessagingService {
 
         Blueshift.updateDeviceToken(newToken);
         BlueshiftAttributesApp.getInstance().updateFirebaseToken(newToken);
-        callIdentify();
-    }
-
-    /**
-     * We are calling an identify here to make sure that the change in
-     * device token is notified to the blueshift servers.
-     */
-    private void callIdentify() {
-        String deviceId = DeviceUtils.getDeviceId(this);
-        Blueshift
-                .getInstance(this)
-                .identifyUserByDeviceId(deviceId, null, false);
+        Blueshift.getInstance(this).identifyUser(null, false);
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageIconFont.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageIconFont.java
@@ -17,15 +17,20 @@ public class InAppMessageIconFont {
     private static Typeface sFontAwesomeFont = null;
     private static InAppMessageIconFont sInstance = null;
 
-    private InAppMessageIconFont(Context context) {
+    private InAppMessageIconFont(final Context context) {
         try {
             if (context != null) {
-                File fontFile = getFontFile(context);
-                if (fontFile.exists()) {
-                    sFontAwesomeFont = Typeface.createFromFile(fontFile);
-                } else {
-                    updateFont(context);
-                }
+                BlueshiftExecutor.getInstance().runOnWorkerThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        File fontFile = getFontFile(context);
+                        if (fontFile.exists()) {
+                            sFontAwesomeFont = Typeface.createFromFile(fontFile);
+                        } else {
+                            updateFont(context);
+                        }
+                    }
+                });
             }
         } catch (Exception e) {
             BlueshiftLogger.e(TAG, e);

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -1,7 +1,6 @@
 package com.blueshift.request_queue;
 
 import android.content.Context;
-import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -250,8 +249,7 @@ class RequestDispatcher {
     }
 
     private void identify(Context context) {
-        String deviceId = DeviceUtils.getDeviceId(context);
-        Blueshift.getInstance(context).identifyUserByDeviceId(deviceId, null, false);
+        Blueshift.getInstance(context).identifyUser(null, false);
     }
 
     /**


### PR DESCRIPTION
Reasons:
- FirebaseInstanceId.getInstance().getId() method call on UI thread.
- Disk access for font file reading made from UI thread.