### PR TITLE
[MOBL-1254] Avoid ANR caused by various reasons

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageIconFont.java
+++ b/android-sdk/src/main/java/com/blueshift/inappmessage/InAppMessageIconFont.java
@@ -17,15 +17,20 @@ public class InAppMessageIconFont {
     private static Typeface sFontAwesomeFont = null;
     private static InAppMessageIconFont sInstance = null;
 
-    private InAppMessageIconFont(Context context) {
+    private InAppMessageIconFont(final Context context) {
         try {
             if (context != null) {
-                File fontFile = getFontFile(context);
-                if (fontFile.exists()) {
-                    sFontAwesomeFont = Typeface.createFromFile(fontFile);
-                } else {
-                    updateFont(context);
-                }
+                BlueshiftExecutor.getInstance().runOnWorkerThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        File fontFile = getFontFile(context);
+                        if (fontFile.exists()) {
+                            sFontAwesomeFont = Typeface.createFromFile(fontFile);
+                        } else {
+                            updateFont(context);
+                        }
+                    }
+                });
             }
         } catch (Exception e) {
             BlueshiftLogger.e(TAG, e);

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -254,8 +254,7 @@ class RequestDispatcher {
     }
 
     private void identify(Context context) {
-        String deviceId = DeviceUtils.getDeviceId(context);
-        Blueshift.getInstance(context).identifyUserByDeviceId(deviceId, null, false);
+        Blueshift.getInstance(context).identifyUser(null, false);
     }
 
     /**


### PR DESCRIPTION
Reasons:
- Disk access for font file reading made from UI thread.

PS: The Firebase IID is already being fetched using async methods. So no change is needed on that side.