### PR TITLE
[MOBL-1409] Changed the url to filename hashing algorithm from MD5 to SHA-256

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueshiftImageCache.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftImageCache.java
@@ -164,7 +164,7 @@ public class BlueshiftImageCache {
         }
 
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA256");
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
             digest.update(s.getBytes());
             byte[] messageDigest = digest.digest();
 

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftImageCache.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftImageCache.java
@@ -57,7 +57,7 @@ public class BlueshiftImageCache {
      */
     @WorkerThread
     public static Bitmap getScaledBitmap(Context context, String url, int reqWidth, int reqHeight) {
-        String key = md5(url);
+        String key = hash(url);
         Bitmap bitmap = null;
 
         if (key != null) {
@@ -121,7 +121,7 @@ public class BlueshiftImageCache {
      */
     @WorkerThread
     public static void clean(Context context, String url) {
-        String key = md5(url);
+        String key = hash(url);
         if (key != null) {
             String fromMemory = removeFromMemCache(key) ? "success" : "failed";
             String fromDisk = removeFromDiskCache(context, key) ? "success" : "failed";
@@ -157,14 +157,14 @@ public class BlueshiftImageCache {
         }
     }
 
-    private static String md5(String s) {
+    private static String hash(String s) {
         if (s == null || "null".equals(s) || s.isEmpty()) {
             BlueshiftLogger.w(TAG, "Invalid image URL: \"" + s + "\"");
             return null;
         }
 
         try {
-            MessageDigest digest = MessageDigest.getInstance("MD5");
+            MessageDigest digest = MessageDigest.getInstance("SHA256");
             digest.update(s.getBytes());
             byte[] messageDigest = digest.digest();
 

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -1088,7 +1088,7 @@ public class InAppUtils {
 
         if (!TextUtils.isEmpty(url)) {
             try {
-                MessageDigest digest = MessageDigest.getInstance("SHA256");
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
                 digest.update(url.getBytes());
                 byte[] byteArray = digest.digest();
 

--- a/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/InAppUtils.java
@@ -1055,7 +1055,7 @@ public class InAppUtils {
     public static File getCachedImageFile(Context context, String url) {
         File imageCacheDir = getImageCacheDir(context);
         if (imageCacheDir != null && imageCacheDir.exists()) {
-            String fileName = getCachedImageFileName(url);
+            String fileName = hash(url);
             File imgFile = new File(imageCacheDir, fileName);
             BlueshiftLogger.d(LOG_TAG, "Image file name. Remote: " + url + ", Local: " + imgFile.getAbsolutePath());
             return imgFile;
@@ -1083,28 +1083,28 @@ public class InAppUtils {
         return imagesDir;
     }
 
-    private static String getCachedImageFileName(String url) {
-        String md5Hash = "";
+    private static String hash(String url) {
+        String hashVal = "";
 
         if (!TextUtils.isEmpty(url)) {
             try {
-                MessageDigest md5 = MessageDigest.getInstance("MD5");
-                md5.update(url.getBytes());
-                byte[] byteArray = md5.digest();
+                MessageDigest digest = MessageDigest.getInstance("SHA256");
+                digest.update(url.getBytes());
+                byte[] byteArray = digest.digest();
 
                 StringBuilder sb = new StringBuilder();
                 for (byte data : byteArray) {
                     sb.append(Integer.toString((data & 0xff) + 0x100, 16).substring(1));
                 }
 
-                md5Hash = sb.toString();
+                hashVal = sb.toString();
 
             } catch (NoSuchAlgorithmException e) {
                 BlueshiftLogger.e(LOG_TAG, e);
             }
         }
 
-        return md5Hash;
+        return hashVal;
     }
 
     public static long timestampToEpochSeconds(String srcTimestamp) {


### PR DESCRIPTION
Based on the warnings from Lift, we are changing the algorithm from MD5 to SHA-256 to make sure that the URL to filename mapping is collision resistant.