### PR TITLE
[MOBL-1331] Added consumer ProGuard/R8 rules

### DIFF
--- a/android-sdk/blueshift-rules.pro
+++ b/android-sdk/blueshift-rules.pro
@@ -1,0 +1,16 @@
+# Address Gson errors with TypeToken
+-keep class com.google.gson.reflect.TypeToken
+-keep class * extends com.google.gson.reflect.TypeToken
+-keep public class * implements java.lang.reflect.Type
+
+# Address Gson errors with abstract classes
+-keep public class * implements java.io.Serializable
+
+# Do not shrink the members of the following classes
+-keepclassmembernames class com.blueshift.batch.BulkEvent {*;}
+-keepclassmembernames class com.blueshift.model.Subscription {*;}
+-keepclassmembernames class com.blueshift.model.UserInfo {*;}
+-keepclassmembernames class com.blueshift.rich_push.Action {*;}
+-keepclassmembernames class com.blueshift.rich_push.Message {*;}
+-keepclassmembernames class com.blueshift.rich_push.CarouselElement {*;}
+-keepclassmembernames class com.blueshift.rich_push.CarouselElementText {*;}

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -15,6 +15,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
+        consumerProguardFiles 'blueshift-rules.pro'
+
         buildConfigField 'String', 'SDK_VERSION', "\"$PUBLISH_VERSION\""
     }
     buildTypes {


### PR DESCRIPTION
Changes
- Added consumer proguard rules to make sure the classes & members that are important for the SDK remain unchanged when minify is enabled on release builds.