### PR TITLE
[MOBL-1431] Remove the code that handles category based deep links

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -21,20 +21,10 @@ public class Configuration {
     private int appIcon;
     private String apiKey;
 
-    // deep linking
-    @Deprecated
-    private Class productPage;
-    @Deprecated
-    private Class cartPage;
-    @Deprecated
-    private Class offerDisplayPage;
-
     // bulk event
     private long batchInterval;
 
     // notifications
-    @Deprecated
-    private int dialogTheme;
     private int smallIconResId;
     private int largeIconResId;
     private int notificationColor;
@@ -122,66 +112,12 @@ public class Configuration {
         this.region = region;
     }
 
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public Class getProductPage() {
-        return productPage;
-    }
-
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public void setProductPage(Class productPage) {
-        this.productPage = productPage;
-    }
-
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public Class getCartPage() {
-        return cartPage;
-    }
-
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public void setCartPage(Class cartPage) {
-        this.cartPage = cartPage;
-    }
-
     public String getApiKey() {
         return apiKey;
     }
 
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
-    }
-
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public Class getOfferDisplayPage() {
-        return offerDisplayPage;
-    }
-
-    /**
-     * @deprecated Category based deep-linking is deprecated. Instead, please use customisable
-     * action buttons. Email us at support@blueshift.com for more details.
-     */
-    @Deprecated
-    public void setOfferDisplayPage(Class offerDisplayPage) {
-        this.offerDisplayPage = offerDisplayPage;
     }
 
     public long getBatchInterval() {
@@ -196,26 +132,6 @@ public class Configuration {
      */
     public void setBatchInterval(long batchInterval) {
         this.batchInterval = batchInterval;
-    }
-
-    /**
-     * @deprecated Dialog notifications are deprecated. Use in-app messages instead.
-     */
-    @Deprecated
-    public int getDialogTheme() {
-        return dialogTheme;
-    }
-
-    /**
-     * Theme used for creating dialog type notifications.
-     * Default value is `Theme.AppCompat.Dialog.Alert`
-     *
-     * @param dialogTheme user define theme's reference id
-     * @deprecated Dialog notifications are deprecated. Use in-app messages instead.
-     */
-    @Deprecated
-    public void setDialogTheme(int dialogTheme) {
-        this.dialogTheme = dialogTheme;
     }
 
     public int getSmallIconResId() {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/CustomNotificationFactory.java
@@ -742,27 +742,18 @@ class CustomNotificationFactory {
      * @return {@link PendingIntent}
      */
     private PendingIntent getCarouselImageClickPendingIntent(Context context, Message message, CarouselElement element, int notificationId) {
-        String action = RichPushConstants.ACTION_OPEN_APP(context); // default is OPEN_APP
-
         Bundle bundle = new Bundle();
         bundle.putInt(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationId);
 
-        if (message != null) {
-            bundle.putString(RichPushConstants.EXTRA_MESSAGE, message.toJson());
-        }
+        if (message != null) bundle.putString(RichPushConstants.EXTRA_MESSAGE, message.toJson());
 
         if (element != null) {
             bundle.putString(RichPushConstants.EXTRA_CAROUSEL_ELEMENT, element.toJson());
-
-            if (element.isDeepLinkingEnabled()) {
-                bundle.putString(RichPushConstants.EXTRA_DEEP_LINK_URL, element.getDeepLinkUrl());
-            } else {
-                action = RichPushConstants.buildAction(context, element.getAction());
-            }
+            bundle.putString(RichPushConstants.EXTRA_DEEP_LINK_URL, element.getDeepLinkUrl());
         }
 
         // get the activity to handle clicks (user defined or sdk defined
-        Intent intent = NotificationUtils.getNotificationEventsActivity(context, action, bundle);
+        Intent intent = NotificationUtils.getNotificationEventsActivity(context, bundle);
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         taskStackBuilder.addNextIntent(intent);
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationCategory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationCategory.java
@@ -8,11 +8,6 @@ import com.blueshift.BlueshiftLogger;
  *         https://github.com/rahulrvp
  */
 public enum NotificationCategory {
-    Buy,
-    ViewCart,
-    Promotion,
-    AlertBoxOpenDismiss,
-    AlertBoxDismiss,
     SilentPush,
     AnimatedCarousel,
     Carousel,
@@ -24,23 +19,6 @@ public enum NotificationCategory {
     public static NotificationCategory fromString(String notificationCategory) {
         if (notificationCategory != null) {
             switch (notificationCategory) {
-                // for regular notifications
-                case "buy":
-                    return Buy;
-
-                case "view_cart":
-                    return ViewCart;
-
-                case "promotion":
-                    return Promotion;
-
-                // for dialog notifications
-                case "alert_box":
-                    return AlertBoxOpenDismiss;
-
-                case "alert_box_1_button":
-                    return AlertBoxDismiss;
-
                 // silent push
                 case "silent_push":
                     return SilentPush;

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -279,12 +279,6 @@ public class NotificationFactory {
     }
 
     static PendingIntent getNotificationClickPendingIntent(String action, Context context, Message message, int notificationId) {
-        // if deep link url is available, despite the fact that we have a category based action,
-        // we will use the open app action to launch app and pass the deep link url to it.
-        if (TextUtils.isEmpty(action) || (message != null && message.isDeepLinkingEnabled())) {
-            action = RichPushConstants.ACTION_OPEN_APP(context);
-        }
-
         // set extra params
         Bundle bundle = new Bundle();
         bundle.putInt(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationId);
@@ -298,7 +292,7 @@ public class NotificationFactory {
         }
 
         // get the activity to handle clicks (user defined or sdk defined
-        Intent intent = NotificationUtils.getNotificationEventsActivity(context, action, bundle);
+        Intent intent = NotificationUtils.getNotificationEventsActivity(context, bundle);
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         taskStackBuilder.addNextIntent(intent);
 
@@ -308,8 +302,6 @@ public class NotificationFactory {
     }
 
     public static PendingIntent getNotificationActionPendingIntent(Context context, Message message, Action pushAction, int notificationId) {
-        String action = RichPushConstants.ACTION_OPEN_APP(context);
-
         // set extra params
         Bundle bundle = new Bundle();
         bundle.putInt(RichPushConstants.EXTRA_NOTIFICATION_ID, notificationId);
@@ -324,7 +316,7 @@ public class NotificationFactory {
         }
 
         // get the activity to handle clicks (user defined or sdk defined
-        Intent intent = NotificationUtils.getNotificationEventsActivity(context, action, bundle);
+        Intent intent = NotificationUtils.getNotificationEventsActivity(context, bundle);
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         taskStackBuilder.addNextIntent(intent);
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -12,9 +12,10 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
+
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.TaskStackBuilder;
-import android.text.TextUtils;
 
 import com.blueshift.Blueshift;
 import com.blueshift.BlueshiftConstants;
@@ -51,10 +52,6 @@ public class NotificationFactory {
     public static void handleMessage(final Context context, final Message message) {
         if (context != null && message != null) {
             switch (message.getNotificationType()) {
-                case AlertDialog:
-                    BlueshiftLogger.d(LOG_TAG, "\"alert\" push messages are deprecated. Use in-app notifications instead.");
-                    break;
-
                 case Notification:
                     buildAndShowNotification(context, message);
                     break;
@@ -104,41 +101,8 @@ public class NotificationFactory {
                     }
                 }
 
-                // pending intent that opens the app using MAIN activity.
                 PendingIntent openAppPendingIntent = getOpenAppPendingIntent(context, message, notificationId);
-
-                switch (message.getCategory()) {
-                    case Buy:
-                        PendingIntent viewPendingIntent = getViewActionPendingIntent(context, message, notificationId);
-                        builder.addAction(0, "View", viewPendingIntent);
-
-                        PendingIntent buyPendingIntent = getBuyActionPendingIntent(context, message, notificationId);
-                        builder.addAction(0, "Buy", buyPendingIntent);
-
-                        builder.setContentIntent(openAppPendingIntent);
-
-                        break;
-
-                    case ViewCart:
-                        PendingIntent openCartPendingIntent = getOpenCartPendingIntent(context, message, notificationId);
-                        builder.addAction(0, "Open Cart", openCartPendingIntent);
-
-                        builder.setContentIntent(openAppPendingIntent);
-
-                        break;
-
-                    case Promotion:
-                        PendingIntent openPromoPendingIntent = getOpenPromotionPendingIntent(context, message, notificationId);
-                        builder.setContentIntent(openPromoPendingIntent);
-
-                        break;
-
-                    default:
-                        /*
-                         * Default action is to open app and send all details as extra inside intent
-                         */
-                        builder.setContentIntent(openAppPendingIntent);
-                }
+                builder.setContentIntent(openAppPendingIntent);
             }
 
             builder.setContentTitle(message.getContentTitle());
@@ -309,30 +273,8 @@ public class NotificationFactory {
         }
     }
 
-    // [BEGIN] PendingIntent builder methods.
-
-    private static PendingIntent getBuyActionPendingIntent(Context context, Message message, int notificationId) {
-        String action = RichPushConstants.ACTION_BUY(context);
-        return getNotificationClickPendingIntent(action, context, message, notificationId);
-    }
-
-    private static PendingIntent getViewActionPendingIntent(Context context, Message message, int notificationId) {
-        String action = RichPushConstants.ACTION_VIEW(context);
-        return getNotificationClickPendingIntent(action, context, message, notificationId);
-    }
-
-    private static PendingIntent getOpenCartPendingIntent(Context context, Message message, int notificationId) {
-        String action = RichPushConstants.ACTION_OPEN_CART(context);
-        return getNotificationClickPendingIntent(action, context, message, notificationId);
-    }
-
     private static PendingIntent getOpenAppPendingIntent(Context context, Message message, int notificationId) {
         String action = RichPushConstants.ACTION_OPEN_APP(context);
-        return getNotificationClickPendingIntent(action, context, message, notificationId);
-    }
-
-    private static PendingIntent getOpenPromotionPendingIntent(Context context, Message message, int notificationId) {
-        String action = RichPushConstants.ACTION_OPEN_OFFER_PAGE(context);
         return getNotificationClickPendingIntent(action, context, message, notificationId);
     }
 
@@ -390,6 +332,4 @@ public class NotificationFactory {
         return taskStackBuilder.getPendingIntent(
                 reqCode, CommonUtils.appendImmutableFlag(PendingIntent.FLAG_ONE_SHOT));
     }
-
-    // [END] PendingIntent builder methods.
 }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationType.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationType.java
@@ -8,7 +8,6 @@ import com.blueshift.BlueshiftLogger;
  *         https://github.com/rahulrvp
  */
 public enum NotificationType {
-    AlertDialog,
     Notification,
     CustomNotification,
     NotificationScheduler,
@@ -19,9 +18,6 @@ public enum NotificationType {
     public static NotificationType fromString(String notificationType) {
         if (notificationType != null) {
             switch (notificationType) {
-                case "alert":
-                    return AlertDialog;
-
                 case "notification":
                     return Notification;
 

--- a/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/RichPushConstants.java
@@ -22,56 +22,14 @@ public final class RichPushConstants {
     /**
      * Actions for the push categories handled by SDK.
      */
-    private static final String sActionView = "ACTION_VIEW";
-    private static final String sActionBuy = "ACTION_BUY";
-    private static final String sActionOpenCart = "ACTION_OPEN_CART";
-    private static final String sActionOpenOfferPage = "ACTION_OPEN_OFFER_PAGE";
     private static final String sActionOpenApp = "ACTION_OPEN_APP";
-
-    public static String ACTION_VIEW(Context context) {
-        return context.getPackageName() + "." + sActionView;
-    }
-
-    public static String ACTION_BUY(Context context) {
-        return context.getPackageName() + "." + sActionBuy;
-    }
-
-    public static String ACTION_OPEN_CART(Context context) {
-        return context.getPackageName() + "." + sActionOpenCart;
-    }
-
-    public static String ACTION_OPEN_OFFER_PAGE(Context context) {
-        return context.getPackageName() + "." + sActionOpenOfferPage;
-    }
 
     public static String ACTION_OPEN_APP(Context context) {
         return context.getPackageName() + "." + sActionOpenApp;
     }
 
     public static String buildAction(Context context, String action) {
-        if (context == null) return null;
-
-        if (action == null) return ACTION_OPEN_APP(context);
-
-        switch (action) {
-            case sActionView:
-                return ACTION_VIEW(context);
-
-            case sActionBuy:
-                return ACTION_BUY(context);
-
-            case sActionOpenCart:
-                return ACTION_OPEN_CART(context);
-
-            case sActionOpenOfferPage:
-                return ACTION_OPEN_OFFER_PAGE(context);
-
-            case sActionOpenApp:
-                return ACTION_OPEN_APP(context);
-
-            default:
-                return ACTION_OPEN_APP(context);
-        }
+        return ACTION_OPEN_APP(context);
     }
 
     /**

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -286,104 +286,6 @@ public class NotificationUtils {
     }
 
     /**
-     * Get the activity marked as cart activity inside the configuration object with extras
-     *
-     * @param context Application's context to get configuration object
-     * @param message Message object to get values required to add inside bundle
-     * @return Valid intent object to launch
-     */
-    public static Intent getAddToCartActivityIntent(Context context, Message message) {
-        Intent pageLauncherIntent = null;
-
-        if (message != null && context != null) {
-            Configuration configuration = BlueshiftUtils.getConfiguration(context);
-            if (configuration != null && configuration.getCartPage() != null) {
-                pageLauncherIntent = new Intent(context, configuration.getCartPage());
-                // add product specific items.
-                pageLauncherIntent.putExtra("product_id", message.getProductId());
-                pageLauncherIntent.putExtra("mrp", message.getMrp());
-                pageLauncherIntent.putExtra("price", message.getPrice());
-                pageLauncherIntent.putExtra("data", message.getData());
-            } else {
-                BlueshiftLogger.i(LOG_TAG, "Could not find cart activity class inside configuration. Opening MAIN activity.");
-            }
-        }
-
-        return pageLauncherIntent;
-    }
-
-    /**
-     * Get the activity marked as cart activity inside the configuration object
-     *
-     * @param context Application's context to get configuration object
-     * @param message Message object to get values required to add inside bundle
-     * @return Valid intent object to launch
-     */
-    public static Intent getViewCartActivityIntent(Context context, Message message) {
-        Intent pageLauncherIntent = null;
-
-        if (message != null && context != null) {
-            Configuration configuration = BlueshiftUtils.getConfiguration(context);
-            if (configuration != null && configuration.getCartPage() != null) {
-                pageLauncherIntent = new Intent(context, configuration.getCartPage());
-            } else {
-                BlueshiftLogger.i(LOG_TAG, "Could not find cart activity class inside configuration. Opening MAIN activity.");
-            }
-        }
-
-        return pageLauncherIntent;
-    }
-
-    /**
-     * Get the activity marked as product details activity inside the configuration object with extras
-     *
-     * @param context Application's context to get configuration object
-     * @param message Message object to get values required to add inside bundle
-     * @return Valid intent object to launch
-     */
-    public static Intent getViewProductActivityIntent(Context context, Message message) {
-        Intent pageLauncherIntent = null;
-
-        if (message != null && context != null) {
-            Configuration configuration = BlueshiftUtils.getConfiguration(context);
-            if (configuration != null && configuration.getProductPage() != null) {
-                pageLauncherIntent = new Intent(context, configuration.getProductPage());
-                // add product specific items.
-                pageLauncherIntent.putExtra("product_id", message.getProductId());
-                pageLauncherIntent.putExtra("mrp", message.getMrp());
-                pageLauncherIntent.putExtra("price", message.getPrice());
-                pageLauncherIntent.putExtra("data", message.getData());
-            } else {
-                BlueshiftLogger.i(LOG_TAG, "Could not find product activity class inside configuration. Opening MAIN activity.");
-            }
-        }
-
-        return pageLauncherIntent;
-    }
-
-    /**
-     * Get the activity marked as offer display activity inside the configuration object
-     *
-     * @param context Application's context to get configuration object
-     * @param message Message object to get values required to add inside bundle
-     * @return Valid intent object to launch
-     */
-    public static Intent getViewOffersActivityIntent(Context context, Message message) {
-        Intent pageLauncherIntent = null;
-
-        if (message != null && context != null) {
-            Configuration configuration = BlueshiftUtils.getConfiguration(context);
-            if (configuration != null && configuration.getOfferDisplayPage() != null) {
-                pageLauncherIntent = new Intent(context, configuration.getOfferDisplayPage());
-            } else {
-                BlueshiftLogger.i(LOG_TAG, "Could not find offer's page activity class inside configuration. Opening MAIN activity.");
-            }
-        }
-
-        return pageLauncherIntent;
-    }
-
-    /**
      * Get the activity marked as LAUNCHER in the AndroidManifest.xml
      *
      * @param context Application's context to get configuration object
@@ -523,25 +425,7 @@ public class NotificationUtils {
     }
 
     private static Intent buildIntentFromAction(Activity activity, Message message, String action) {
-        Intent intent = null;
-
-        if (!TextUtils.isEmpty(action)) {
-            if (action.equals(RichPushConstants.ACTION_OPEN_APP(activity))) {
-                intent = NotificationUtils.getOpenAppIntent(activity, message);
-            } else if (action.equals(RichPushConstants.ACTION_VIEW(activity))) {
-                intent = NotificationUtils.getViewProductActivityIntent(activity, message);
-            } else if (action.equals(RichPushConstants.ACTION_BUY(activity))) {
-                intent = NotificationUtils.getAddToCartActivityIntent(activity, message);
-            } else if (action.equals(RichPushConstants.ACTION_OPEN_CART(activity))) {
-                intent = NotificationUtils.getViewCartActivityIntent(activity, message);
-            } else if (action.equals(RichPushConstants.ACTION_OPEN_OFFER_PAGE(activity))) {
-                intent = NotificationUtils.getViewOffersActivityIntent(activity, message);
-            }
-        }
-
-        if (intent == null) intent = NotificationUtils.getOpenAppIntent(activity, message);
-
-        return intent;
+        return NotificationUtils.getOpenAppIntent(activity, message);
     }
 
     private static void launchUrl(Activity activity, String url, String clickElement) {

--- a/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
+++ b/android-sdk/src/main/java/com/blueshift/util/NotificationUtils.java
@@ -216,6 +216,17 @@ public class NotificationUtils {
      * Checks for the activity responsible for handling notification clicks based on the action.
      *
      * @param context context object to create intent
+     * @param extras  extra params as bundle
+     * @return Intent object to launch activity.
+     */
+    public static Intent getNotificationEventsActivity(Context context, Bundle extras) {
+        return getNotificationEventsActivity(context, null, extras);
+    }
+
+    /**
+     * Checks for the activity responsible for handling notification clicks based on the action.
+     *
+     * @param context context object to create intent
      * @param action  action string
      * @param extras  extra params as bundle
      * @return Intent object to launch activity.
@@ -361,7 +372,7 @@ public class NotificationUtils {
      * @return true: if the click was handled by the sdk, false: if the click was not handled by the sdk.
      */
     public static boolean processNotificationClick(Activity activity, String action, Bundle bundle) {
-        if (activity != null && action != null && bundle != null) {
+        if (activity != null && bundle != null) {
             Message message = Message.fromBundle(bundle);
             if (message != null) {
                 try {
@@ -378,7 +389,7 @@ public class NotificationUtils {
                     if (BlueshiftUtils.isPushAppLinksEnabled(activity)) {
                         launchUrl(activity, deepLink, clickElement);
                     } else {
-                        Intent intent = buildIntentFromAction(activity, message, action);
+                        Intent intent = NotificationUtils.getOpenAppIntent(activity, message);
                         if (intent == null) return false; // if intent is null, abort here.
 
                         // add complete bundle to the intent.
@@ -417,15 +428,11 @@ public class NotificationUtils {
             }
         } else {
             BlueshiftLogger.d(LOG_TAG, "processNotificationClick: Invalid arguments " +
-                    "(activity: " + activity + ", action: " + action + ", bundle: " + bundle + ").");
+                    "(activity: " + activity + ", bundle: " + bundle + ").");
         }
 
         // click was not handled by Blueshift SDK
         return false;
-    }
-
-    private static Intent buildIntentFromAction(Activity activity, Message message, String action) {
-        return NotificationUtils.getOpenAppIntent(activity, message);
     }
 
     private static void launchUrl(Activity activity, String url, String clickElement) {


### PR DESCRIPTION
Category-based deep links were deprecated last year. Support for the same was removed from the dashboard and replaced with custom action buttons. This change removes the code from SDK that are not reachable now.