### PR TITLE
[MOBL-1657] Avoid app crashes due to missing component error for JobScheduler

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
+++ b/android-sdk/src/main/java/com/blueshift/batch/BulkEventManager.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.SystemClock;
+
 import androidx.annotation.RequiresApi;
 
 import com.blueshift.Blueshift;
@@ -68,18 +69,21 @@ public class BulkEventManager {
 
                     final JobInfo jobInfo = builder.build();
 
-                    BlueshiftExecutor.getInstance().runOnNetworkThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (jobScheduler != null && JobScheduler.RESULT_SUCCESS == jobScheduler.schedule(jobInfo)) {
-                                BlueshiftLogger.d(LOG_TAG, "Bulk event job scheduled.");
-                            } else {
-                                // for some reason job scheduling failed. log this.
-                                BlueshiftLogger.d(LOG_TAG, "Bulk event job scheduling failed.");
+                    BlueshiftExecutor.getInstance().runOnNetworkThread(() -> {
+                        if (jobScheduler != null) {
+                            try {
+                                if (JobScheduler.RESULT_SUCCESS == jobScheduler.schedule(jobInfo)) {
+                                    BlueshiftLogger.d(LOG_TAG, "Job scheduled successfully! (Bulk Events Job)");
+                                } else {
+                                    BlueshiftLogger.w(LOG_TAG, "Job scheduling failed! (Bulk Events Job)");
+                                }
+                            } catch (Exception e) {
+                                BlueshiftLogger.e(LOG_TAG, e);
                             }
+                        } else {
+                            BlueshiftLogger.w(LOG_TAG, "JobScheduler instance is null (Bulk Events Job)");
                         }
                     });
-
                 }
             }
         } catch (Exception e) {

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestQueue.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestQueue.java
@@ -58,17 +58,15 @@ public class RequestQueue {
 
                             final JobInfo jobInfo = builder.build();
 
-                            BlueshiftExecutor.getInstance().runOnNetworkThread(new Runnable() {
-                                @Override
-                                public void run() {
+                            BlueshiftExecutor.getInstance().runOnNetworkThread(() -> {
+                                try {
                                     if (JobScheduler.RESULT_SUCCESS == jobScheduler.schedule(jobInfo)) {
-                                        BlueshiftLogger.i(LOG_TAG, "Successfully scheduled request queue " +
-                                                "sync job on network change");
+                                        BlueshiftLogger.d(LOG_TAG, "Job scheduled successfully! (Request Queue Job)");
                                     } else {
-                                        // for some reason job scheduling failed. log this.
-                                        BlueshiftLogger.w(LOG_TAG, "Could not schedule request queue sync " +
-                                                "job on network change");
+                                        BlueshiftLogger.w(LOG_TAG, "Job scheduling failed! (Request Queue Job)");
                                     }
+                                } catch (Exception e) {
+                                    BlueshiftLogger.e(LOG_TAG, e);
                                 }
                             });
                         }


### PR DESCRIPTION
This avoids app crashes by catching the exception that happens when scheduling a job using JobScheduler. The reason for the exception is the unavailability of **JobService** instance at the time of calling **schedule** method. The JobService instance is embedded in the SDK and is registered in the AnndroidManifest as well. The reason behind the issue is unknown.