### PR TITLE
[MOBL-1803] Sending explicit intents in internal broadcasts to support Android 14 (API Level 34) or higher

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/inbox/BlueshiftInboxManager.java
+++ b/android-sdk/src/main/java/com/blueshift/inbox/BlueshiftInboxManager.java
@@ -309,6 +309,8 @@ public class BlueshiftInboxManager {
     private static void sendBroadcast(Context context, String action, Bundle extras) {
         if (context != null && action != null && !action.isEmpty()) {
             Intent bcIntent = new Intent(action);
+            bcIntent.setPackage(context.getPackageName());
+
             if (extras != null) {
                 bcIntent.putExtras(extras);
             }

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -268,6 +268,7 @@ public class NotificationFactory {
                                     BlueshiftLogger.i(LOG_TAG, "Scheduled a notification. Display time: " + sdf.format(timeToDisplay));
                                 } else {
                                     BlueshiftLogger.i(LOG_TAG, "Display time (" + sdf.format(timeToDisplay) + ") elapsed! Showing the notification now.");
+                                    bcIntent.setPackage(context.getPackageName());
                                     context.sendBroadcast(bcIntent);
                                 }
                             } else {


### PR DESCRIPTION
Sending explicit intents in internal broadcasts to support Android 14 (API Level 34) or higher ([reference](https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents))