### PR TITLE
[MOBL-1809] AGP version updated to 7.4.2 and enabled Kotlin (version 1.9.0) for the android-sdk module

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 ext {
     PUBLISH_GROUP_ID = 'com.blueshift'
@@ -25,10 +26,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.core:core-ktx:1.13.0'
     androidTestImplementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation 'com.google.truth:truth:1.1.4'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {

--- a/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
+++ b/android-sdk/src/main/java/com/blueshift/rich_push/NotificationFactory.java
@@ -127,7 +127,7 @@ public class NotificationFactory {
                     // Set the large icon to match the big picture.
                     builder.setLargeIcon(bitmap);
                     // Hide the large icon when the notification is expanded.
-                    bigPictureStyle.bigLargeIcon(null);
+                    bigPictureStyle.bigLargeIcon((Bitmap) null);
 
                     if (!TextUtils.isEmpty(message.getBigContentTitle())) {
                         bigPictureStyle.setBigContentTitle(message.getBigContentTitle());

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        agp_version = '7.4.2'
+        kotlin_version = '1.9.0'
+    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath "com.android.tools.build:gradle:$agp_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 03 14:50:14 IST 2023
+#Tue Apr 30 16:55:39 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What changed?
- Android Gradle Plugin (AGP) version updated to 7.4.2
- Enabled Kotlin (1.9.0) for the android-sdk module