### PR TITLE
[MOBL-1811] Gradle = 8.6, AGP = 8.4.0, Kotlin = 1.9.23, targetSdkVersion = 34

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 ext {
     PUBLISH_GROUP_ID = 'com.blueshift'
     PUBLISH_ARTIFACT_ID = 'android-sdk-x'
-    PUBLISH_VERSION = '3.4.8'
+    PUBLISH_VERSION = '3.4.6'
 }
 
 android {

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -4,21 +4,24 @@ apply plugin: 'org.jetbrains.kotlin.android'
 ext {
     PUBLISH_GROUP_ID = 'com.blueshift'
     PUBLISH_ARTIFACT_ID = 'android-sdk-x'
-    PUBLISH_VERSION = '3.4.6'
+    PUBLISH_VERSION = '3.4.8'
 }
 
 android {
     namespace "$PUBLISH_GROUP_ID"
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField 'String', 'SDK_VERSION', "\"$PUBLISH_VERSION\""
+    }
+    buildFeatures {
+        buildConfig true
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     ext {
-        agp_version = '7.4.2'
-        kotlin_version = '1.9.0'
+        agp_version = '8.4.0'
+        kotlin_version = '1.9.23'
     }
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 30 16:55:39 IST 2024
+#Fri May 03 17:58:36 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -28,7 +28,7 @@ task javadoc(type: Javadoc) {
 
 // build a jar with javadoc
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 


### PR DESCRIPTION
We are bumping the Gradle, Android Gradle Plugin (AGP), and Kotlin versions to target the Android API level 34.