### PR TITLE
[MOBL-1821] Addressed a significant UI lag introduced in v3.4.6. 

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -44,8 +44,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -385,6 +387,17 @@ public class Blueshift {
      * When a change is detected, an event will be sent to Blueshift to report the same.
      */
     void doAppVersionChecks(Context context) {
+        List<Object> result = inferAppVersionChangeEvent(context);
+        if (result != null && result.size() == 2) {
+            String eventName = (String) result.get(0);
+            HashMap<String, Object> extras = (HashMap<String, Object>) result.get(1);
+            trackEvent(eventName, extras, false);
+        }
+    }
+
+    List<Object> inferAppVersionChangeEvent(Context context) {
+        List<Object> result = new ArrayList<>();
+
         if (context != null) {
             final String appVersionString = CommonUtils.getAppVersion(context);
 
@@ -410,14 +423,18 @@ public class Blueshift {
 
                         HashMap<String, Object> extras = new HashMap<>();
                         extras.put(BlueshiftConstants.KEY_APP_UPDATED_AT, CommonUtils.getCurrentUtcTimestamp());
-                        sendEvent(BlueshiftConstants.EVENT_APP_UPDATE, extras, false);
+
+                        result.add(BlueshiftConstants.EVENT_APP_UPDATE);
+                        result.add(extras);
                     } else {
                         // cases 1 & 2
                         BlueshiftLogger.d(LOG_TAG, "appVersion: db file NOT found at " + database.getAbsolutePath());
 
                         HashMap<String, Object> extras = new HashMap<>();
                         extras.put(BlueshiftConstants.KEY_APP_INSTALLED_AT, CommonUtils.getCurrentUtcTimestamp());
-                        sendEvent(BlueshiftConstants.EVENT_APP_INSTALL, extras, false);
+
+                        result.add(BlueshiftConstants.EVENT_APP_INSTALL);
+                        result.add(extras);
                     }
 
                     BlueShiftPreference.saveAppVersionString(context, appVersionString);
@@ -435,7 +452,9 @@ public class Blueshift {
                         HashMap<String, Object> extras = new HashMap<>();
                         extras.put(BlueshiftConstants.KEY_PREVIOUS_APP_VERSION, storedAppVersionString);
                         extras.put(BlueshiftConstants.KEY_APP_UPDATED_AT, CommonUtils.getCurrentUtcTimestamp());
-                        sendEvent(BlueshiftConstants.EVENT_APP_UPDATE, extras, false);
+
+                        result.add(BlueshiftConstants.EVENT_APP_UPDATE);
+                        result.add(extras);
 
                         BlueShiftPreference.saveAppVersionString(context, appVersionString);
                     } else {
@@ -444,7 +463,10 @@ public class Blueshift {
                 }
             }
         }
+
+        return result;
     }
+
 
     /**
      * Check if a notification icon is provided, else use app icon

--- a/android-sdk/src/test/java/com/blueshift/BlueshiftTest.java
+++ b/android-sdk/src/test/java/com/blueshift/BlueshiftTest.java
@@ -1,6 +1,6 @@
 package com.blueshift;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 
 public class BlueshiftTest {
     @Test
@@ -30,10 +31,14 @@ public class BlueshiftTest {
         when(CommonUtils.getAppVersion(context)).thenReturn("1.0.0");
 
         Blueshift blueshift = Blueshift.getInstance(context);
-        blueshift.doAppVersionChecks(context);
+        List<Object> result = blueshift.inferAppVersionChangeEvent(context);
 
-        // confirm if the sendEvent was called with event name app_install
-        assertFalse(blueshift.sendEvent("app_install", null, false));
+        // assert that the item in 0th index of result is "app_install"
+        assertEquals("app_install", result.get(0));
+
+        // assert that the hashmap in 1st index of result has key "app_installed_at"
+        HashMap<String, Object> map = (HashMap<String, Object>) result.get(1);
+        assertEquals("app_installed_at", map.keySet().iterator().next());
     }
 
     @Test
@@ -52,10 +57,14 @@ public class BlueshiftTest {
         when(CommonUtils.getAppVersion(context)).thenReturn("2.0.0");
 
         Blueshift blueshift = Blueshift.getInstance(context);
-        blueshift.doAppVersionChecks(context);
+        List<Object> result = blueshift.inferAppVersionChangeEvent(context);
 
-        // confirm if the sendEvent was called with event name app_update
-        assertFalse(blueshift.sendEvent("app_update", null, false));
+        // assert that the item in 0th index of result is "app_update"
+        assertEquals("app_update", result.get(0));
+
+        // assert that the hashmap in 1st index of result has key "app_updated_at"
+        HashMap<String, Object> map = (HashMap<String, Object>) result.get(1);
+        assertEquals("app_updated_at", map.keySet().iterator().next());
     }
 
     @Test
@@ -74,9 +83,13 @@ public class BlueshiftTest {
         when(CommonUtils.getAppVersion(context)).thenReturn("2.0.0");
 
         Blueshift blueshift = Blueshift.getInstance(context);
-        blueshift.doAppVersionChecks(context);
+        List<Object> result = blueshift.inferAppVersionChangeEvent(context);
 
-        // confirm if the sendEvent was called with event name app_update
-        assertFalse(blueshift.sendEvent("app_update", null, false));
+        // assert that the item in 0th index of result is "app_install"
+        assertEquals("app_install", result.get(0));
+
+        // assert that the hashmap in 1st index of result has key "app_installed_at"
+        HashMap<String, Object> map = (HashMap<String, Object>) result.get(1);
+        assertEquals("app_installed_at", map.keySet().iterator().next());
     }
 }


### PR DESCRIPTION
The UI lag was caused due to a call to get the advertising ID from the UI thread. This resulted from using the sendEvent method instead of the trackEvent method provided by the Blueshift class.