### PR TITLE
[MOBL-1834] Remove the cached email from SharedPreferences

### DIFF
--- a/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
+++ b/android-sdk/src/main/java/com/blueshift/BlueShiftPreference.java
@@ -126,31 +126,6 @@ public class BlueShiftPreference {
         return true;
     }
 
-    public static boolean isEmailAlreadyIdentified(Context context, String email) {
-        boolean result = false;
-
-        if (context != null && !TextUtils.isEmpty(email)) {
-            SharedPreferences preferences = getEmailPreference(context);
-            if (preferences != null) {
-                result = preferences.getBoolean(email, false);
-            }
-        }
-
-        return result;
-    }
-
-    public static void markEmailAsIdentified(Context context, String email) {
-        if (context != null && !TextUtils.isEmpty(email)) {
-            SharedPreferences preferences = getEmailPreference(context);
-            if (preferences != null) {
-                preferences
-                        .edit()
-                        .putBoolean(email, true)
-                        .apply();
-            }
-        }
-    }
-
     private static SharedPreferences getBlueshiftPreferences(Context context) {
         SharedPreferences preferences = null;
 
@@ -159,6 +134,13 @@ public class BlueShiftPreference {
         }
 
         return preferences;
+    }
+
+    public static void removeCachedEmailAddress(Context context) {
+        SharedPreferences preferences = getEmailPreference(context);
+        if (preferences != null) {
+            preferences.edit().clear().apply();
+        }
     }
 
     private static SharedPreferences getEmailPreference(Context context) {

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -355,7 +355,7 @@ public class Blueshift {
         mConfiguration = configuration;
 
         // initialize the encrypted shared preferences if enabled.
-        if (configuration.shouldEncryptUserInfo()) {
+        if (configuration.shouldSaveUserInfoAsEncrypted()) {
             BlueshiftEncryptedPreferences.INSTANCE.init(mContext);
         }
 

--- a/android-sdk/src/main/java/com/blueshift/Blueshift.java
+++ b/android-sdk/src/main/java/com/blueshift/Blueshift.java
@@ -354,7 +354,10 @@ public class Blueshift {
     public void initialize(@NonNull Configuration configuration) {
         mConfiguration = configuration;
 
-        BlueshiftEncryptedPreferences.INSTANCE.init(mContext);
+        // initialize the encrypted shared preferences if enabled.
+        if (configuration.shouldEncryptUserInfo()) {
+            BlueshiftEncryptedPreferences.INSTANCE.init(mContext);
+        }
 
         BlueshiftAttributesApp.getInstance().init(mContext);
         doAppVersionChecks(mContext);

--- a/android-sdk/src/main/java/com/blueshift/BlueshiftEncryptedPreferences.kt
+++ b/android-sdk/src/main/java/com/blueshift/BlueshiftEncryptedPreferences.kt
@@ -6,7 +6,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 
 object BlueshiftEncryptedPreferences {
-    private val PREF_NAME = "blueshift_sdk_preferences"
+    private const val PREF_NAME = "com.blueshift.encrypted.preferences"
 
     private lateinit var sharedPreferences: SharedPreferences
 

--- a/android-sdk/src/main/java/com/blueshift/model/Configuration.java
+++ b/android-sdk/src/main/java/com/blueshift/model/Configuration.java
@@ -60,7 +60,7 @@ public class Configuration {
 
     // Defines is we should store user info in plain text or in encrypted form.
     // Default value is false to make it backward compatible.
-    private  boolean shouldEncryptUserInfo = false;
+    private  boolean saveUserInfoAsEncrypted = false;
 
     public Configuration() {
         // Setting default region to the US.
@@ -98,12 +98,12 @@ public class Configuration {
         autoAppOpenInterval = 86400;
     }
 
-    public boolean shouldEncryptUserInfo() {
-        return shouldEncryptUserInfo;
+    public boolean shouldSaveUserInfoAsEncrypted() {
+        return saveUserInfoAsEncrypted;
     }
 
-    public void setShouldEncryptUserInfo(boolean shouldEncryptUserInfo) {
-        this.shouldEncryptUserInfo = shouldEncryptUserInfo;
+    public void setSaveUserInfoAsEncrypted(boolean saveUserInfoAsEncrypted) {
+        this.saveUserInfoAsEncrypted = saveUserInfoAsEncrypted;
     }
 
     public boolean isPushAppLinksEnabled() {

--- a/android-sdk/src/main/java/com/blueshift/model/UserInfo.java
+++ b/android-sdk/src/main/java/com/blueshift/model/UserInfo.java
@@ -71,11 +71,11 @@ public class UserInfo {
         }
     }
 
-    private static String getLegacyPreferenceFile(@NonNull Context context) {
+    private static String getSharedPreferencesFilename(@NonNull Context context) {
         return context.getPackageName() + "." + PREF_FILE;
     }
 
-    private static String getLegacyPreferenceKey(@NonNull Context context) {
+    private static String getSharedPreferencesKey(@NonNull Context context) {
         return context.getPackageName() + "." + PREF_KEY;
     }
 
@@ -86,15 +86,15 @@ public class UserInfo {
     }
 
     static UserInfo load(Context context, boolean encryptionEnabled) {
-        return encryptionEnabled ? loadEncrypted(context) : loadLegacy(context);
+        return encryptionEnabled ? loadFromEncryptedSharedPreferences(context) : loadFromSharedPreferences(context);
     }
 
-    private static UserInfo loadLegacy(@NonNull Context context) {
+    private static UserInfo loadFromSharedPreferences(@NonNull Context context) {
         UserInfo userInfo = null;
 
-        BlueshiftLogger.d(TAG, "Loading from legacy shared preference.");
-        SharedPreferences preferences = context.getSharedPreferences(getLegacyPreferenceFile(context), Context.MODE_PRIVATE);
-        String json = preferences.getString(getLegacyPreferenceKey(context), null);
+        BlueshiftLogger.d(TAG, "Loading from SharedPreferences.");
+        SharedPreferences preferences = context.getSharedPreferences(getSharedPreferencesFilename(context), Context.MODE_PRIVATE);
+        String json = preferences.getString(getSharedPreferencesKey(context), null);
         if (json != null) {
             try {
                 userInfo = new Gson().fromJson(json, UserInfo.class);
@@ -106,7 +106,7 @@ public class UserInfo {
         return userInfo;
     }
 
-    private static UserInfo loadEncrypted(@NonNull Context context) {
+    private static UserInfo loadFromEncryptedSharedPreferences(@NonNull Context context) {
         UserInfo userInfo = null;
 
         BlueshiftLogger.d(TAG, "Loading from encrypted preference.");
@@ -114,19 +114,19 @@ public class UserInfo {
         if (json == null) {
             // The new secure store doesn't have the user info. Let's check in the old preference
             // file and copy over the data if present.
-            SharedPreferences pref = context.getSharedPreferences(getLegacyPreferenceFile(context), Context.MODE_PRIVATE);
-            String legacyJson = pref.getString(getLegacyPreferenceKey(context), null);
-            if (legacyJson != null) {
-                BlueshiftLogger.d(TAG, "Found data inside the legacy preference. Copying it to the encrypted preference.");
+            SharedPreferences pref = context.getSharedPreferences(getSharedPreferencesFilename(context), Context.MODE_PRIVATE);
+            String spUserJson = pref.getString(getSharedPreferencesKey(context), null);
+            if (spUserJson != null) {
+                BlueshiftLogger.d(TAG, "Found user data inside the SharedPreferences. Copying it to the EncryptedSharedPreferences.");
                 try {
-                    userInfo = new Gson().fromJson(legacyJson, UserInfo.class);
+                    userInfo = new Gson().fromJson(spUserJson, UserInfo.class);
                     // Save it to secure store for loading next time.
-                    userInfo.saveEncrypted();
+                    userInfo.saveToEncryptedSharedPreferences();
                     // Clear the old preference for privacy reasons.
-                    BlueshiftLogger.d(TAG, "Clear the legacy preference.");
+                    BlueshiftLogger.d(TAG, "Clear the SharedPreferences.");
                     pref.edit().clear().apply();
                     // Remove cached email address information (If found)
-                    BlueshiftLogger.d(TAG, "Clear the email preference.");
+                    BlueshiftLogger.d(TAG, "Clear the email from SharedPreferences.");
                     BlueShiftPreference.removeCachedEmailAddress(context);
                 } catch (Exception e) {
                     BlueshiftLogger.e(TAG, e);
@@ -185,19 +185,19 @@ public class UserInfo {
 
     void save(Context context, boolean encryptionEnabled) {
         if (encryptionEnabled) {
-            saveEncrypted();
+            saveToEncryptedSharedPreferences();
         } else {
-            saveLegacy(context);
+            saveToSharedPreferences(context);
         }
     }
 
-    private void saveLegacy(Context context) {
+    private void saveToSharedPreferences(Context context) {
         String json = new Gson().toJson(this);
-        context.getSharedPreferences(getLegacyPreferenceFile(context), Context.MODE_PRIVATE)
-                .edit().putString(getLegacyPreferenceKey(context), json).apply();
+        context.getSharedPreferences(getSharedPreferencesFilename(context), Context.MODE_PRIVATE)
+                .edit().putString(getSharedPreferencesKey(context), json).apply();
     }
 
-    private void saveEncrypted() {
+    private void saveToEncryptedSharedPreferences() {
         String json = new Gson().toJson(this);
         BlueshiftEncryptedPreferences.INSTANCE.putString(PREF_KEY_ENCRYPTED, json);
     }

--- a/android-sdk/src/main/java/com/blueshift/model/UserInfo.java
+++ b/android-sdk/src/main/java/com/blueshift/model/UserInfo.java
@@ -81,7 +81,7 @@ public class UserInfo {
 
     private static UserInfo load(@NonNull Context context) {
         Configuration configuration = BlueshiftUtils.getConfiguration(context);
-        boolean isEncryptionEnabled = configuration != null && configuration.shouldEncryptUserInfo();
+        boolean isEncryptionEnabled = configuration != null && configuration.shouldSaveUserInfoAsEncrypted();
         return load(context, isEncryptionEnabled);
     }
 
@@ -179,7 +179,7 @@ public class UserInfo {
 
     public void save(@NonNull Context context) {
         Configuration configuration = BlueshiftUtils.getConfiguration(context);
-        boolean isEncryptionEnabled = configuration != null && configuration.shouldEncryptUserInfo();
+        boolean isEncryptionEnabled = configuration != null && configuration.shouldSaveUserInfoAsEncrypted();
         save(context, isEncryptionEnabled);
     }
 

--- a/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
+++ b/android-sdk/src/main/java/com/blueshift/request_queue/RequestDispatcher.java
@@ -224,22 +224,8 @@ class RequestDispatcher {
     }
 
     private void doAutoIdentifyCheck(Context context) {
-        boolean identified = didEmailChange(context) || didPushPermissionChange(context);
+        boolean identified = didPushPermissionChange(context);
         if (identified) BlueshiftLogger.d(LOG_TAG, "Auto identify call fired.");
-    }
-
-    private boolean didEmailChange(Context context) {
-        UserInfo userInfo = UserInfo.getInstance(context);
-        if (userInfo != null && !TextUtils.isEmpty(userInfo.getEmail())) {
-            if (!BlueShiftPreference.isEmailAlreadyIdentified(context, userInfo.getEmail())) {
-                identify(context);
-                BlueShiftPreference.markEmailAsIdentified(context, userInfo.getEmail());
-                BlueshiftLogger.d(LOG_TAG, "Change in email detected. Sending \"identify\".");
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private boolean didPushPermissionChange(Context context) {


### PR DESCRIPTION
This change removes the email address stored in the SharedPreference for tracking the change in email address. The identify event fired when the email address is changed is not disabled. The app should explicitly fire the identify event when user info changes.